### PR TITLE
Ciphertext/Plaintext Serialization Bindings

### DIFF
--- a/orion/backend/lattigo/bindings.py
+++ b/orion/backend/lattigo/bindings.py
@@ -199,6 +199,30 @@ class LattigoLibrary:
             restype=None
         )
 
+        self.SerializeCiphertext = LattigoFunction(
+            self.lib.SerializeCiphertext,
+            argtypes=[ctypes.c_int],
+            restype=ArrayResultByte
+        )
+
+        self.LoadCiphertext = LattigoFunction(
+            self.lib.LoadCiphertext,
+            argtypes=[ctypes.POINTER(ctypes.c_ubyte), ctypes.c_ulong],
+            restype=ctypes.c_int
+        )
+
+        self.SerializePlaintext = LattigoFunction(
+            self.lib.SerializePlaintext,
+            argtypes=[ctypes.c_int],
+            restype=ArrayResultByte
+        )
+
+        self.LoadPlaintext = LattigoFunction(
+            self.lib.LoadPlaintext,
+            argtypes=[ctypes.POINTER(ctypes.c_ubyte), ctypes.c_ulong],
+            restype=ctypes.c_int
+        )
+
         self.GetPlaintextScale = LattigoFunction(
             self.lib.GetPlaintextScale,
             argtypes=[ctypes.c_int],

--- a/orion/backend/lattigo/utils.go
+++ b/orion/backend/lattigo/utils.go
@@ -21,6 +21,10 @@ func CArrayToByteSlice(dataPtr unsafe.Pointer, length uint64) []byte {
 	return unsafe.Slice((*byte)(dataPtr), length)
 }
 
+func CCharArrayToByteSlice(dataPtr *C.char, length C.ulong) []byte {
+	return unsafe.Slice((*byte)(unsafe.Pointer(dataPtr)), int(length))
+}
+
 func convertFloatToCFloat(v float64) C.float {
 	return C.float(v)
 }


### PR DESCRIPTION
This pull request introduces serialization and deserialization functions for Lattigo ciphertexts and plaintexts in the Go backend and exposes them in the Python bindings. The main motivation is to enable a server–client architecture where encrypted objects can be transmitted between a server and one or more clients.

I am not entirely sure if it is done correctly, but from a first test it works.
