### PR TITLE
Add DeSiLo FHE backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,4 +34,52 @@ pip install -e .
 ```
 uv sync
 uv run examples/run_lola.py
+uv run examples/run_mlp.py
+uv run examples/run_resnet.py
+```
+
+#### Running with the DeSiLo backend
+
+To run with the [DeSiLo FHE](https://fhe.desilo.dev/latest/) backend instead of Lattigo:
+
+```
+uv pip install desilofhe
+```
+
+```
+uv run examples/run_lola.py configs/lola_desilo.yml
+uv run examples/run_mlp.py configs/mlp_desilo.yml
+uv run examples/run_resnet.py configs/resnet_desilo.yml
+```
+
+> **Note:** ResNet uses bootstrapping and requires ~32 GB RAM. LoLA and MLP run on a standard laptop.
+
+##### CPU vs GPU
+
+The DeSiLo backend runs on CPU by default. To select the device, add a `device` field under the `orion:` block of the config:
+
+```yaml
+orion:
+  backend: desilo
+  device: cpu   # "cpu" (default) or "gpu"
+```
+
+GPU mode requires a CUDA-capable NVIDIA GPU and a CUDA-enabled install of `desilofhe` (see the [DeSiLo docs](https://fhe.desilo.dev/latest/) for installation details). To run any of the examples on GPU, set `device: gpu` in the corresponding `*_desilo.yml` config and re-run the same command — no other changes needed.
+
+The Lattigo backend is CPU-only; the `device` field has no effect when `backend: lattigo`.
+
+#### Running oracle tests
+
+```
+uv run pytest tests/oracle/ -v -s
+```
+
+To run with DeSiLo:
+```
+uv run pytest tests/oracle/ -v -s --backend=desilo
+```
+
+Bootstrap tests are skipped by default. To include them:
+```
+uv run pytest tests/oracle/ -v -s --backend=desilo -m ""
 ```

--- a/configs/lola_desilo.yml
+++ b/configs/lola_desilo.yml
@@ -1,0 +1,21 @@
+comment: Config for LoLA from Figure 3 of https://arxiv.org/pdf/1812.10659
+
+ckks_params:
+  LogN: 13
+  LogQ: [29, 26, 26, 26, 26, 26]
+  LogP: [29, 29]
+  LogScale: 26
+  H: 8192
+  RingType: ConjugateInvariant
+
+orion:
+  margin: 2 # >= 1
+  embedding_method: hybrid # [hybrid, square]
+  backend: desilo
+
+  fuse_modules: true
+  debug: false
+
+  diags_path: ../data/diagonals.h5 # "path/to/diags" | ""
+  keys_path: ../data/keys.h5 # "path/to/keys" | ""
+  io_mode: none # "load" | "save" | "none"

--- a/configs/mlp_desilo.yml
+++ b/configs/mlp_desilo.yml
@@ -1,0 +1,21 @@
+comment: Config for MLP from https://eprint.iacr.org/2017/396.pdf
+
+ckks_params:
+  LogN: 13
+  LogQ: [29, 26, 26, 26, 26, 26]
+  LogP: [29, 29]
+  LogScale: 26
+  H: 8192
+  RingType: ConjugateInvariant
+
+orion:
+  margin: 2 # >= 1
+  embedding_method: hybrid # [hybrid, square]
+  backend: desilo
+
+  fuse_modules: true
+  debug: false
+
+  diags_path: ../data/diagonals.h5 # "path/to/diags" | ""
+  keys_path: ../data/keys.h5 # "path/to/keys" | ""
+  io_mode: none # "load" | "save" | "none"

--- a/configs/resnet_desilo.yml
+++ b/configs/resnet_desilo.yml
@@ -1,0 +1,24 @@
+comment: "ResNet Parameter Set"
+
+ckks_params:
+  LogN: 16
+  LogQ: [55, 40, 40, 40, 40, 40, 40, 40, 40, 40, 40]
+  LogP: [61, 61, 61]
+  LogScale: 40
+  H: 192
+  RingType: standard
+
+boot_params:
+  LogP: [61, 61, 61, 61, 61, 61, 61, 61]
+
+orion:
+  margin: 2 # >= 1
+  embedding_method: hybrid # [hybrid, square]
+  backend: desilo
+
+  fuse_modules: true
+  debug: true
+
+  diags_path: ../data/diagonals.h5 # "path/to/diags" | ""
+  keys_path: ../data/keys.h5 # "path/to/keys" | ""
+  io_mode: none # "load" | "save" | "none"

--- a/examples/run_lola.py
+++ b/examples/run_lola.py
@@ -1,3 +1,4 @@
+import sys
 import time
 import math
 import torch
@@ -9,7 +10,8 @@ from orion.core.utils import get_mnist_datasets, mae, train_on_mnist
 torch.manual_seed(42)
 
 # Initialize the Orion scheme, model, and data
-scheme = orion.init_scheme("./configs/lola.yml")
+config = sys.argv[1] if len(sys.argv) > 1 else "./configs/lola.yml"
+scheme = orion.init_scheme(config)
 trainloader, testloader = get_mnist_datasets(data_dir="./data", batch_size=1)
 net = models.LoLA()
 

--- a/examples/run_mlp.py
+++ b/examples/run_mlp.py
@@ -1,3 +1,4 @@
+import sys
 import time
 import math
 import torch
@@ -5,7 +6,7 @@ import orion
 import orion.models as models
 from orion.core.utils import (
     get_mnist_datasets,
-    mae, 
+    mae,
     train_on_mnist
 )
 
@@ -13,8 +14,9 @@ from orion.core.utils import (
 torch.manual_seed(42)
 
 # Initialize the Orion scheme, model, and data
-scheme = orion.init_scheme("../configs/mlp.yml")
-trainloader, testloader = get_mnist_datasets(data_dir="../data", batch_size=1)
+config = sys.argv[1] if len(sys.argv) > 1 else "./configs/mlp.yml"
+scheme = orion.init_scheme(config)
+trainloader, testloader = get_mnist_datasets(data_dir="./data", batch_size=1)
 net = models.MLP()
 
 # Train model (optional)

--- a/examples/run_resnet.py
+++ b/examples/run_resnet.py
@@ -1,3 +1,4 @@
+import sys
 import time
 import math
 import torch
@@ -5,7 +6,7 @@ import orion
 import orion.models as models
 from orion.core.utils import (
     get_cifar_datasets,
-    mae, 
+    mae,
     train_on_cifar
 )
 
@@ -13,8 +14,9 @@ from orion.core.utils import (
 torch.manual_seed(42)
 
 # Initialize the Orion scheme, model, and data
-scheme = orion.init_scheme("../configs/resnet.yml")
-trainloader, testloader = get_cifar_datasets(data_dir="../data", batch_size=1)
+config = sys.argv[1] if len(sys.argv) > 1 else "./configs/resnet.yml"
+scheme = orion.init_scheme(config)
+trainloader, testloader = get_cifar_datasets(data_dir="./data", batch_size=1)
 net = models.ResNet20()
 
 # Train model (optional)

--- a/orion/backend/desilo/bindings.py
+++ b/orion/backend/desilo/bindings.py
@@ -1,0 +1,800 @@
+"""DeSiLo FHE backend — drop-in replacement for the Lattigo backend.
+
+Exposes the same ID-based interface as LattigoLibrary so the Python
+wrapper layer (orion/backend/python/) works unchanged.
+"""
+
+import numpy as np
+import desilofhe
+
+
+class DeSiLoLibrary:
+    """DeSiLo FHE backend implementing the LattigoLibrary interface."""
+
+    def __init__(self):
+        self.engine = None
+
+        # ID-based object registry (mirrors Lattigo's integer-ID approach)
+        self._objects = {}      # id -> native DeSiLo object
+        self._next_id = 1
+        self._scales = {}       # id -> scale metadata (DeSiLo doesn't expose scale)
+        self._obj_type = {}     # id -> "pt" | "ct" (for GetLive* queries)
+
+        # Keys (stored internally, passed explicitly to DeSiLo operations)
+        self._sk = None
+        self._pk = None
+        self._rk = None
+        self._rot_key = None
+        self._conj_key = None
+
+        # Scheme params
+        self._default_scale = None
+        self._max_level = None
+        self._slots = None
+
+        # Polynomial storage: poly_id -> (coeffs_ascending, type)
+        self._polynomials = {}
+
+        # Linear transform storage: lt_id -> dict with diag data
+        self._transforms = {}
+
+    # ------------------------------------------------------------------
+    #  Internal helpers
+    # ------------------------------------------------------------------
+
+    def _store(self, obj, kind, scale=None):
+        """Store a DeSiLo object, return integer ID."""
+        oid = self._next_id
+        self._next_id += 1
+        self._objects[oid] = obj
+        self._obj_type[oid] = kind
+        if scale is not None:
+            self._scales[oid] = scale
+        return oid
+
+    def _get(self, oid):
+        return self._objects[oid]
+
+    def _delete(self, oid):
+        self._objects.pop(oid, None)
+        self._scales.pop(oid, None)
+        self._obj_type.pop(oid, None)
+
+    def _replace(self, oid, new_obj):
+        """Replace object at existing ID (for in-place operations)."""
+        self._objects[oid] = new_obj
+        return oid
+
+    # ------------------------------------------------------------------
+    #  setup_bindings  (called by Scheme.setup_backend)
+    # ------------------------------------------------------------------
+
+    def setup_bindings(self, orion_params):
+        self.setup_scheme(orion_params)
+        self.setup_tensor_binds()
+        self.setup_key_generator()
+        self.setup_encoder()
+        self.setup_encryptor()
+        self.setup_evaluator()
+        self.setup_poly_evaluator()
+        self.setup_lt_evaluator()
+        self.setup_bootstrapper()
+
+    # ------------------------------------------------------------------
+    #  Scheme setup
+    # ------------------------------------------------------------------
+
+    def setup_scheme(self, orion_params):
+        logq = orion_params.get_logq()
+        logscale = orion_params.get_logscale()
+
+        self._max_level = len(logq) - 1
+        self._default_scale = 1 << logscale
+        self._slots = orion_params.get_slots()
+
+        # Detect bootstrap requirement: boot_logp differs from logp when
+        # the config explicitly provides boot_params.
+        boot_logp = orion_params.get_boot_logp()
+        logp = orion_params.get_logp()
+        self._use_bootstrap = (boot_logp != logp)
+        self._device = orion_params.get_device()
+
+        if self._use_bootstrap:
+            print(f"[DeSiLo] Creating BOOTSTRAP engine: "
+                  f"slot_count={self._slots}, device={self._device}")
+            self.engine = desilofhe.Engine(
+                use_bootstrap=True, slot_count=self._slots, mode=self._device)
+        else:
+            print(f"[DeSiLo] Creating engine: target max_level="
+                  f"{self._max_level}, slots={self._slots}, device={self._device}")
+            self.engine = desilofhe.Engine(self._max_level, mode=self._device)
+
+        print(f"[DeSiLo] Engine ready: max_level={self.engine.max_level}, "
+              f"slot_count={self.engine.slot_count}")
+
+        if self.engine.slot_count != self._slots:
+            print(f"[DeSiLo] WARNING: slot_count mismatch — "
+                  f"engine={self.engine.slot_count}, expected={self._slots}")
+
+    def DeleteScheme(self):
+        self._objects.clear()
+        self._scales.clear()
+        self._obj_type.clear()
+        self._polynomials.clear()
+        self._transforms.clear()
+        self._sk = None
+        self._pk = None
+        self._rk = None
+        self._rot_key = None
+        self._conj_key = None
+        self.engine = None
+
+    def FreeCArray(self, ptr=None):
+        pass  # No C memory to free in DeSiLo
+
+    # ------------------------------------------------------------------
+    #  Tensor metadata binds
+    # ------------------------------------------------------------------
+
+    def setup_tensor_binds(self):
+        pass  # Methods defined directly on this class
+
+    def DeletePlaintext(self, pt_id):
+        self._delete(pt_id)
+
+    def DeleteCiphertext(self, ct_id):
+        self._delete(ct_id)
+
+    def GetPlaintextScale(self, pt_id):
+        return self._scales.get(pt_id, self._default_scale)
+
+    def GetCiphertextScale(self, ct_id):
+        return self._scales.get(ct_id, self._default_scale)
+
+    def SetPlaintextScale(self, pt_id, scale):
+        self._scales[pt_id] = scale
+
+    def SetCiphertextScale(self, ct_id, scale):
+        self._scales[ct_id] = scale
+
+    def GetPlaintextLevel(self, pt_id):
+        return self._get(pt_id).level
+
+    def GetCiphertextLevel(self, ct_id):
+        return self._get(ct_id).level
+
+    def GetPlaintextSlots(self, pt_id):
+        return self.engine.slot_count
+
+    def GetCiphertextSlots(self, ct_id):
+        return self.engine.slot_count
+
+    def GetCiphertextDegree(self, ct_id):
+        return 1  # Always relinearized in our usage
+
+    def GetModuliChain(self):
+        # DeSiLo manages scale internally, so the exact prime values don't
+        # affect computation. We return a list of the default scale repeated
+        # for each level so that callers (bootstrap, batch norm, composite
+        # activations) can index by level without crashing.
+        # This is a compatibility stub — redundant if we drop Lattigo support
+        # and refactor the wrapper layer to stop querying the moduli chain.
+        return [self._default_scale] * (self.engine.max_level + 1)
+
+    def GetAuxModuliChain(self):
+        return []
+
+    def GetLivePlaintexts(self):
+        return [k for k, v in self._obj_type.items() if v == "pt"]
+
+    def GetLiveCiphertexts(self):
+        return [k for k, v in self._obj_type.items() if v == "ct"]
+
+    # ------------------------------------------------------------------
+    #  Key generation
+    # ------------------------------------------------------------------
+
+    def setup_key_generator(self):
+        pass
+
+    def NewKeyGenerator(self):
+        pass  # Engine handles key generation directly
+
+    def GenerateSecretKey(self):
+        self._sk = self.engine.create_secret_key()
+        print(f"[DeSiLo] Secret key generated")
+
+    def GeneratePublicKey(self):
+        self._pk = self.engine.create_public_key(self._sk)
+        print(f"[DeSiLo] Public key generated")
+
+    def GenerateRelinearizationKey(self):
+        self._rk = self.engine.create_relinearization_key(self._sk)
+        print(f"[DeSiLo] Relinearization key generated")
+
+    def GenerateEvaluationKeys(self):
+        self._rot_key = self.engine.create_rotation_key(self._sk)
+        self._conj_key = self.engine.create_conjugation_key(self._sk)
+        print(f"[DeSiLo] Evaluation keys generated (rotation + conjugation)")
+
+    def SerializeSecretKey(self):
+        data = self.engine.serialize_secret_key(self._sk)
+        return np.frombuffer(data, dtype=np.uint8), None
+
+    def LoadSecretKey(self, byte_data):
+        self._sk = self.engine.deserialize_secret_key(bytes(byte_data))
+
+    # ------------------------------------------------------------------
+    #  Encode / Decode
+    # ------------------------------------------------------------------
+
+    def setup_encoder(self):
+        pass
+
+    def NewEncoder(self):
+        pass
+
+    def Encode(self, values, level, scale):
+        pt = self.engine.encode(values, level=level)
+        return self._store(pt, "pt", scale=scale)
+
+    def Decode(self, pt_id):
+        pt = self._get(pt_id)
+        result = self.engine.decode(pt)
+        return result.real.tolist()
+
+    # ------------------------------------------------------------------
+    #  Encrypt / Decrypt
+    # ------------------------------------------------------------------
+
+    def setup_encryptor(self):
+        pass
+
+    def NewEncryptor(self):
+        pass
+
+    def NewDecryptor(self):
+        pass
+
+    def Encrypt(self, pt_id):
+        pt = self._get(pt_id)
+        ct = self.engine.encrypt(pt, self._pk)
+        scale = self._scales.get(pt_id, self._default_scale)
+        return self._store(ct, "ct", scale=scale)
+
+    def Decrypt(self, ct_id):
+        ct = self._get(ct_id)
+        pt = self.engine.decrypt_to_plaintext(ct, self._sk)
+        scale = self._scales.get(ct_id, self._default_scale)
+        return self._store(pt, "pt", scale=scale)
+
+    # ------------------------------------------------------------------
+    #  Evaluator setup
+    # ------------------------------------------------------------------
+
+    def setup_evaluator(self):
+        pass
+
+    def NewEvaluator(self):
+        pass
+
+    # ------------------------------------------------------------------
+    #  Rotation
+    # ------------------------------------------------------------------
+
+    def AddRotationKey(self, k):
+        pass  # General rotation key already covers all deltas
+
+    def Rotate(self, ct_id, k):
+        ct = self._get(ct_id)
+        # CRITICAL: negate k — Lattigo positive k = left-shift,
+        # DeSiLo positive delta = right-shift
+        result = self.engine.rotate(ct, self._rot_key, delta=-k)
+        return self._replace(ct_id, result)
+
+    def RotateNew(self, ct_id, k):
+        ct = self._get(ct_id)
+        result = self.engine.rotate(ct, self._rot_key, delta=-k)
+        scale = self._scales.get(ct_id, self._default_scale)
+        return self._store(result, "ct", scale=scale)
+
+    # ------------------------------------------------------------------
+    #  Negate
+    # ------------------------------------------------------------------
+
+    def Negate(self, ct_id):
+        ct = self._get(ct_id)
+        result = self.engine.negate(ct)
+        scale = self._scales.get(ct_id, self._default_scale)
+        return self._store(result, "ct", scale=scale)
+
+    # ------------------------------------------------------------------
+    #  Rescale  (no-op — DeSiLo auto-rescales during multiply)
+    # ------------------------------------------------------------------
+
+    def Rescale(self, ct_id):
+        return ct_id
+
+    def RescaleNew(self, ct_id):
+        ct = self._get(ct_id)
+        result = self.engine.clone(ct)
+        scale = self._scales.get(ct_id, self._default_scale)
+        return self._store(result, "ct", scale=scale)
+
+    # ------------------------------------------------------------------
+    #  Scalar arithmetic
+    # ------------------------------------------------------------------
+
+    def AddScalar(self, ct_id, scalar):
+        ct = self._get(ct_id)
+        result = self.engine.add(ct, float(scalar))
+        return self._replace(ct_id, result)
+
+    def AddScalarNew(self, ct_id, scalar):
+        ct = self._get(ct_id)
+        result = self.engine.add(ct, float(scalar))
+        scale = self._scales.get(ct_id, self._default_scale)
+        return self._store(result, "ct", scale=scale)
+
+    def SubScalar(self, ct_id, scalar):
+        ct = self._get(ct_id)
+        result = self.engine.subtract(ct, float(scalar))
+        return self._replace(ct_id, result)
+
+    def SubScalarNew(self, ct_id, scalar):
+        ct = self._get(ct_id)
+        result = self.engine.subtract(ct, float(scalar))
+        scale = self._scales.get(ct_id, self._default_scale)
+        return self._store(result, "ct", scale=scale)
+
+    def MulScalarInt(self, ct_id, scalar):
+        ct = self._get(ct_id)
+        result = self.engine.multiply(ct, int(scalar))
+        return self._replace(ct_id, result)
+
+    def MulScalarIntNew(self, ct_id, scalar):
+        ct = self._get(ct_id)
+        result = self.engine.multiply(ct, int(scalar))
+        scale = self._scales.get(ct_id, self._default_scale)
+        return self._store(result, "ct", scale=scale)
+
+    def MulScalarFloat(self, ct_id, scalar):
+        ct = self._get(ct_id)
+        result = self.engine.multiply(ct, float(scalar))
+        return self._replace(ct_id, result)
+
+    def MulScalarFloatNew(self, ct_id, scalar):
+        ct = self._get(ct_id)
+        result = self.engine.multiply(ct, float(scalar))
+        scale = self._scales.get(ct_id, self._default_scale)
+        return self._store(result, "ct", scale=scale)
+
+    # ------------------------------------------------------------------
+    #  Plaintext arithmetic
+    # ------------------------------------------------------------------
+
+    def AddPlaintext(self, ct_id, pt_id):
+        ct, pt = self._get(ct_id), self._get(pt_id)
+        result = self.engine.add(ct, pt)
+        return self._replace(ct_id, result)
+
+    def AddPlaintextNew(self, ct_id, pt_id):
+        ct, pt = self._get(ct_id), self._get(pt_id)
+        result = self.engine.add(ct, pt)
+        scale = self._scales.get(ct_id, self._default_scale)
+        return self._store(result, "ct", scale=scale)
+
+    def SubPlaintext(self, ct_id, pt_id):
+        ct, pt = self._get(ct_id), self._get(pt_id)
+        result = self.engine.subtract(ct, pt)
+        return self._replace(ct_id, result)
+
+    def SubPlaintextNew(self, ct_id, pt_id):
+        ct, pt = self._get(ct_id), self._get(pt_id)
+        result = self.engine.subtract(ct, pt)
+        scale = self._scales.get(ct_id, self._default_scale)
+        return self._store(result, "ct", scale=scale)
+
+    def MulPlaintext(self, ct_id, pt_id):
+        ct, pt = self._get(ct_id), self._get(pt_id)
+        result = self.engine.multiply(ct, pt)
+        return self._replace(ct_id, result)
+
+    def MulPlaintextNew(self, ct_id, pt_id):
+        ct, pt = self._get(ct_id), self._get(pt_id)
+        result = self.engine.multiply(ct, pt)
+        scale = self._scales.get(ct_id, self._default_scale)
+        return self._store(result, "ct", scale=scale)
+
+    # ------------------------------------------------------------------
+    #  Ciphertext arithmetic
+    # ------------------------------------------------------------------
+
+    def AddCiphertext(self, ct_id1, ct_id2):
+        ct1, ct2 = self._get(ct_id1), self._get(ct_id2)
+        result = self.engine.add(ct1, ct2)
+        return self._replace(ct_id1, result)
+
+    def AddCiphertextNew(self, ct_id1, ct_id2):
+        ct1, ct2 = self._get(ct_id1), self._get(ct_id2)
+        result = self.engine.add(ct1, ct2)
+        scale = self._scales.get(ct_id1, self._default_scale)
+        return self._store(result, "ct", scale=scale)
+
+    def SubCiphertext(self, ct_id1, ct_id2):
+        ct1, ct2 = self._get(ct_id1), self._get(ct_id2)
+        result = self.engine.subtract(ct1, ct2)
+        return self._replace(ct_id1, result)
+
+    def SubCiphertextNew(self, ct_id1, ct_id2):
+        ct1, ct2 = self._get(ct_id1), self._get(ct_id2)
+        result = self.engine.subtract(ct1, ct2)
+        scale = self._scales.get(ct_id1, self._default_scale)
+        return self._store(result, "ct", scale=scale)
+
+    def MulRelinCiphertext(self, ct_id1, ct_id2):
+        ct1, ct2 = self._get(ct_id1), self._get(ct_id2)
+        result = self.engine.multiply(ct1, ct2, self._rk)
+        return self._replace(ct_id1, result)
+
+    def MulRelinCiphertextNew(self, ct_id1, ct_id2):
+        ct1, ct2 = self._get(ct_id1), self._get(ct_id2)
+        result = self.engine.multiply(ct1, ct2, self._rk)
+        scale = self._scales.get(ct_id1, self._default_scale)
+        return self._store(result, "ct", scale=scale)
+
+    # ------------------------------------------------------------------
+    #  Polynomial evaluation
+    # ------------------------------------------------------------------
+
+    def setup_poly_evaluator(self):
+        pass
+
+    def NewPolynomialEvaluator(self):
+        pass
+
+    def GenerateMonomial(self, coeffs):
+        """Store monomial coefficients. The wrapper already reversed them
+        to ascending order [a0, a1, ..., an] before calling this."""
+        poly_id = self._next_id
+        self._next_id += 1
+        self._polynomials[poly_id] = (list(coeffs), "monomial")
+        return poly_id
+
+    def GenerateChebyshev(self, coeffs):
+        """Store Chebyshev coefficients [a0, a1, ..., an]."""
+        poly_id = self._next_id
+        self._next_id += 1
+        self._polynomials[poly_id] = (list(coeffs), "chebyshev")
+        return poly_id
+
+    def EvaluatePolynomial(self, ct_id, poly_id, scale):
+        ct = self._get(ct_id)
+        coeffs, poly_type = self._polynomials[poly_id]
+
+        if poly_type == "monomial":
+            result = self.engine.evaluate_polynomial(ct, coeffs, self._rk)
+        else:  # chebyshev
+            # DeSiLo rejects Chebyshev polys when all non-constant
+            # coefficients have |value| < 1.0.  Fall back to monomial
+            # basis (mathematically equivalent, same level consumption).
+            has_large_nonconst = any(abs(c) >= 1.0 for c in coeffs[1:])
+            if has_large_nonconst:
+                result = self.engine.evaluate_chebyshev_polynomial(
+                    ct, coeffs, self._rk)
+            else:
+                from numpy.polynomial.chebyshev import cheb2poly
+                mono_coeffs = cheb2poly(coeffs).tolist()
+                result = self.engine.evaluate_polynomial(
+                    ct, mono_coeffs, self._rk)
+
+        return self._store(result, "ct", scale=self._default_scale)
+
+    @staticmethod
+    def _fit_chebyshev_standard_basis(x, y, degree):
+        """Least-squares fit in the standard Chebyshev basis T_n(x).
+
+        Unlike numpy's Chebyshev.fit this performs NO domain mapping,
+        so the returned coefficients c satisfy:
+            sum_j c[j] * T_j(x) ≈ y
+        for the actual x values provided.
+        """
+        n = degree + 1
+        T = np.zeros((len(x), n))
+        T[:, 0] = 1.0
+        if n > 1:
+            T[:, 1] = x
+        for j in range(2, n):
+            T[:, j] = 2.0 * x * T[:, j - 1] - T[:, j - 2]
+        coeffs, _, _, _ = np.linalg.lstsq(T, y, rcond=None)
+        return coeffs
+
+    @staticmethod
+    def _eval_chebyshev_standard_basis(x, coeffs):
+        """Evaluate polynomial in standard Chebyshev basis."""
+        n = len(coeffs)
+        T = np.zeros((len(x), n))
+        T[:, 0] = 1.0
+        if n > 1:
+            T[:, 1] = x
+        for j in range(2, n):
+            T[:, j] = 2.0 * x * T[:, j - 1] - T[:, j - 2]
+        return T @ coeffs
+
+    def GenerateMinimaxSignCoeffs(self, degrees, prec, logalpha, logerr, debug):
+        """Generate composite sign polynomial coefficients.
+
+        Each stage is fitted on the *output range* of the previous stage
+        (matching Lattigo's composite Remez strategy) so that the
+        composition converges towards sign(x).
+
+        The first n-1 polynomials approximate sign(x) in {-1, 1}.
+        The last polynomial approximates step(x) in {0, 1}, matching
+        Lattigo's convention (used by _Sign / ReLU: x * step(x)).
+        """
+        gap = 2.0 ** (-logalpha)
+        domain_min, domain_max = -1.0, 1.0
+        current_gap = gap
+
+        coeffs_flat = []
+        for i, deg in enumerate(degrees):
+            is_last = (i == len(degrees) - 1)
+            n_pts = max(8 * deg, 500)
+
+            x_neg = np.linspace(domain_min, -current_gap, n_pts)
+            x_pos = np.linspace(current_gap, domain_max, n_pts)
+            x = np.concatenate([x_neg, x_pos])
+
+            if is_last:
+                y = np.where(x > 0, 1.0, 0.0)
+            else:
+                y = np.sign(x)
+
+            coeffs = self._fit_chebyshev_standard_basis(x, y, deg)
+            coeffs_flat.extend(coeffs[:deg + 1].tolist())
+
+            if not is_last:
+                # Determine output range for the next stage
+                dense_neg = np.linspace(domain_min, -current_gap, 2000)
+                dense_pos = np.linspace(current_gap, domain_max, 2000)
+                dense = np.concatenate([dense_neg, dense_pos])
+                output = self._eval_chebyshev_standard_basis(dense, coeffs)
+
+                domain_min = float(output.min())
+                domain_max = float(output.max())
+
+                # New gap: the polynomial's value at the old gap boundary
+                near_gap = np.array([current_gap, -current_gap])
+                near_out = self._eval_chebyshev_standard_basis(near_gap, coeffs)
+                current_gap = float(min(abs(near_out[0]), abs(near_out[1])))
+                # Ensure gap doesn't collapse to zero
+                current_gap = max(current_gap, 1e-12)
+
+        return coeffs_flat
+
+    # ------------------------------------------------------------------
+    #  Linear transform
+    # ------------------------------------------------------------------
+
+    def setup_lt_evaluator(self):
+        pass
+
+    def NewLinearTransformEvaluator(self):
+        pass
+
+    def GenerateLinearTransform(self, diags_idxs, diags_data, level,
+                                bsgs_ratio, io_mode):
+        """Store diagonal data as numpy arrays for later evaluation."""
+        slots = self.engine.slot_count
+        num_diags = len(diags_idxs)
+        values_per_diag = len(diags_data) // num_diags
+
+        diags = {}
+        for i, idx in enumerate(diags_idxs):
+            start = i * values_per_diag
+            end = start + values_per_diag
+            diag_vals = diags_data[start:end]
+            if len(diag_vals) < slots:
+                diag_vals = diag_vals + [0.0] * (slots - len(diag_vals))
+            diags[idx] = np.array(diag_vals[:slots], dtype=np.float64)
+
+        lt_id = self._next_id
+        self._next_id += 1
+        self._transforms[lt_id] = {
+            "diags": diags,
+            "level": level,
+            "bsgs_ratio": bsgs_ratio,
+        }
+        return lt_id
+
+    def EvaluateLinearTransform(self, lt_id, ct_id):
+        """Evaluate linear transform via diagonal rotation method.
+
+        For each diagonal k with values d_k:
+            result[i] += d_k[i] * input[(i+k) % n]
+
+        Uses BSGS (Baby-step Giant-step) when bsgs_ratio is set, reducing
+        rotations from O(N) to O(2*sqrt(N)). Falls back to naive loop when
+        bsgs_ratio is "none" (e.g. oracle tests).
+        """
+        ct = self._get(ct_id)
+        transform = self._transforms[lt_id]
+        diags = transform["diags"]
+        bsgs_ratio = transform["bsgs_ratio"]
+
+        use_bsgs = (bsgs_ratio not in ("none", None)
+                     and len(diags) > 1)
+
+        if use_bsgs:
+            result = self._eval_lt_bsgs(ct, diags, int(bsgs_ratio))
+        else:
+            result = self._eval_lt_naive(ct, diags)
+
+        return self._store(result, "ct", scale=self._default_scale)
+
+    def _eval_lt_naive(self, ct, diags):
+        """Naive diagonal loop using individual rotate calls."""
+        ct_level = ct.level
+        result = None
+        for diag_idx, diag_arr in diags.items():
+            # Rotate ciphertext (negate: Lattigo left-shift vs DeSiLo right-shift)
+            if diag_idx == 0:
+                ct_rot = self.engine.clone(ct)
+            else:
+                ct_rot = self.engine.rotate(
+                    ct, self._rot_key, delta=-diag_idx)
+
+            # Encode diagonal and multiply
+            pt_diag = self.engine.encode(diag_arr, level=ct_level)
+            prod = self.engine.multiply(ct_rot, pt_diag)
+
+            if result is None:
+                result = prod
+            else:
+                result = self.engine.add(result, prod)
+        return result
+
+    def _eval_lt_bsgs(self, ct, diags, bsgs_ratio):
+        """BSGS-optimized diagonal evaluation.
+
+        Decomposes each diagonal index k = b + g*bs (baby + giant*stride).
+        Precomputes bs baby-step rotations, then for each giant step
+        accumulates inner products and applies one giant-step rotation.
+        Reduces total rotations from O(N) to O(2*sqrt(N)).
+
+        Uses individual engine.rotate() calls instead of rotate_batch()
+        to avoid segfaults with large numbers of rotations.
+        """
+        import math
+        num_diags = len(diags)
+        bs = max(1, math.ceil(math.sqrt(num_diags * bsgs_ratio)))
+        ct_level = ct.level
+
+        # Group diagonals by giant step
+        giant_groups = {}  # g -> list of (b, k, arr)
+        for k, arr in diags.items():
+            b = k % bs
+            g = k // bs
+            giant_groups.setdefault(g, []).append((b, k, arr))
+
+        # Precompute baby-step rotations using individual rotate calls
+        needed_babies = sorted({b for group in giant_groups.values()
+                                for b, _, _ in group})
+        baby_rots = {}
+        for b in needed_babies:
+            if b == 0:
+                baby_rots[0] = self.engine.clone(ct)
+            else:
+                baby_rots[b] = self.engine.rotate(
+                    ct, self._rot_key, delta=-b)
+
+        # Accumulate over giant steps
+        result = None
+        for g, group in giant_groups.items():
+            inner = None
+            for b, k, arr in group:
+                # Pre-rotate plaintext values to compensate for
+                # the giant-step rotation applied below.
+                if g != 0:
+                    shifted = np.roll(arr, g * bs)
+                else:
+                    shifted = arr
+
+                # Encode the diagonal values and multiply
+                pt_diag = self.engine.encode(shifted, level=ct_level)
+                prod = self.engine.multiply(baby_rots[b], pt_diag)
+
+                if inner is None:
+                    inner = prod
+                else:
+                    inner = self.engine.add(inner, prod)
+
+            # Apply giant-step rotation (negate for direction convention)
+            if g != 0:
+                inner = self.engine.rotate(
+                    inner, self._rot_key, delta=-(g * bs))
+
+            if result is None:
+                result = inner
+            else:
+                result = self.engine.add(result, inner)
+
+        return result
+
+    def DeleteLinearTransform(self, lt_id):
+        self._transforms.pop(lt_id, None)
+
+    def GetLinearTransformRotationKeys(self, lt_id):
+        # DeSiLo uses general rotation key; return empty list
+        return []
+
+    def GenerateLinearTransformRotationKey(self, k):
+        pass  # General rotation key covers all
+
+    def GenerateAndSerializeRotationKey(self, k):
+        # Return dummy data — DeSiLo uses general rotation key
+        data = self.engine.serialize_rotation_key(self._rot_key)
+        return np.frombuffer(data, dtype=np.uint8), None
+
+    def LoadRotationKey(self, byte_data, k=None):
+        pass  # General rotation key already loaded
+
+    def SerializeDiagonal(self, lt_id, diag_idx):
+        # Stub for I/O mode serialization
+        return np.array([], dtype=np.uint8), None
+
+    def LoadPlaintextDiagonal(self, byte_data, lt_id, diag_idx):
+        pass
+
+    def RemovePlaintextDiagonals(self, lt_id):
+        pass
+
+    def RemoveRotationKeys(self):
+        pass
+
+    # ------------------------------------------------------------------
+    #  Bootstrap
+    # ------------------------------------------------------------------
+
+    def setup_bootstrapper(self):
+        self._boot_key = None
+
+    def NewBootstrapper(self, logPs, slots):
+        """Create a bootstrap key for the given slot count.
+
+        DeSiLo's bootstrap uses a single BootstrapKey created from the
+        secret key.  The logPs parameter (Lattigo-specific auxiliary prime
+        sizes) is ignored — DeSiLo manages its own auxiliary primes.
+        """
+        if self._sk is None:
+            raise RuntimeError(
+                "[DeSiLo] Cannot create bootstrap key: secret key not "
+                "generated yet.")
+
+        print(f"[DeSiLo] Creating bootstrap key for slots={slots} ...")
+        # Free previous bootstrap key to reclaim GPU memory before
+        # allocating a new one (each key is ~12GB on GPU).
+        if self._boot_key is not None:
+            del self._boot_key
+            self._boot_key = None
+            import gc; gc.collect()
+        self._boot_key = self.engine.create_bootstrap_key(self._sk)
+        print(f"[DeSiLo] Bootstrap key ready.")
+
+    def Bootstrap(self, ct_id, slots):
+        ct = self._get(ct_id)
+        if self._boot_key is None:
+            raise RuntimeError(
+                "[DeSiLo] No bootstrap key. Call NewBootstrapper first.")
+
+        # Caller (nn.operations.Bootstrap) is required to prescale values into
+        # [-1, 1] and drive the ciphertext to level 0 before invoking this.
+        ct = self.engine.intt(ct)
+        result = self.engine.bootstrap(
+            ct, self._rk, self._conj_key, self._boot_key)
+
+        scale = self._scales.get(ct_id, self._default_scale)
+        return self._store(result, "ct", scale=scale)
+
+    def DeleteBootstrappers(self):
+        self._boot_key = None

--- a/orion/backend/python/parameters.py
+++ b/orion/backend/python/parameters.py
@@ -74,6 +74,7 @@ class OrionParameters:
     debug: bool = True
     embedding_method: Literal["hybrid", "square"] = "hybrid"
     backend: Literal["lattigo", "openfhe", "heaan"] = "lattigo"
+    device: Literal["cpu", "gpu"] = "cpu"
     io_mode: Literal["none", "save", "load"] = "none"
     diags_path: str = ""
     keys_path: str = ""
@@ -85,7 +86,8 @@ class OrionParameters:
             f"  Margin: {self.margin}",
             f"  Embedding Method: {self.embedding_method}",
             f"  Fuse Modules: {self.fuse_modules}",
-            f"  Debug Mode: {self.debug}"
+            f"  Debug Mode: {self.debug}",
+            f"  Device: {self.device}"
         ]
         
         output.append(f"  I/O Mode: {self.io_mode}")
@@ -141,6 +143,9 @@ class NewParameters:
 
     def get_backend(self):
         return self.orion_params.backend.lower()
+
+    def get_device(self):
+        return self.orion_params.device.lower()
     
     def get_logq(self):
         return self.ckks_params.logq

--- a/orion/core/orion.py
+++ b/orion/core/orion.py
@@ -10,6 +10,7 @@ from torch.utils.data import DataLoader, RandomSampler
 from orion.nn.module import Module
 from orion.nn.linear import LinearTransform
 from orion.backend.lattigo import bindings as lgo
+from orion.backend.desilo import bindings as dsl
 from orion.backend.python import (
     parameters, 
     key_generator,
@@ -92,6 +93,10 @@ class Scheme:
             py_lattigo = lgo.LattigoLibrary()
             py_lattigo.setup_bindings(params)
             return py_lattigo
+        elif backend == "desilo":
+            py_desilo = dsl.DeSiLoLibrary()
+            py_desilo.setup_bindings(params)
+            return py_desilo
         elif backend in ("heaan", "openfhe"):
             raise ValueError(f"Backend {backend} not yet supported.")
         else:

--- a/orion/nn/activation.py
+++ b/orion/nn/activation.py
@@ -21,11 +21,17 @@ class Activation(Module):
     
     def set_depth(self):
         self.depth = int(math.ceil(math.log2(len(self.coeffs))))
+        # DeSiLo poly evaluation consumes 1 extra level for degree > 2
+        if (self.scheme is not None
+                and self.scheme.params.get_backend() == "desilo"
+                and len(self.coeffs) > 3):
+            self.depth += 1
 
     def set_output_scale(self, output_scale):
         self.output_scale = output_scale
 
     def compile(self):
+        self.set_depth()  # recompute now that backend info is available
         self.poly = self.scheme.poly_evaluator.generate_monomial(self.coeffs)
 
     @timer
@@ -95,6 +101,11 @@ class Chebyshev(Module):
     def set_depth(self):
         self.depth = int(math.ceil(math.log2(self.degree+1)))
         if self.prescale != 1: # additional level needed
+            self.depth += 1
+        # DeSiLo poly evaluation consumes 1 extra level for degree > 2
+        if (self.scheme is not None
+                and self.scheme.params.get_backend() == "desilo"
+                and self.degree > 2):
             self.depth += 1
 
     def set_output_scale(self, output_scale):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,10 @@ dependencies = [
     "certifi>=2024.2.2",
 ]
 
+[tool.pytest.ini_options]
+markers = ["slow: marks tests as slow (bootstrap, large params)"]
+addopts = "-m 'not slow'"
+
 [tool.poetry]
 packages = [{include = "orion"}]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,37 @@
+"""Root test conftest — provides --backend option to override FHE backend.
+
+Usage:
+    # Run oracle tests with DeSiLo backend:
+    .venv/bin/python -m pytest tests/oracle/ -v -s --backend=desilo
+
+    # Run with Lattigo (default, no override needed):
+    .venv/bin/python -m pytest tests/oracle/ -v
+"""
+
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--backend",
+        default=None,
+        help="Override FHE backend (e.g. 'desilo', 'lattigo')",
+    )
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _patch_backend(request):
+    """If --backend is given, monkeypatch Scheme.setup_backend to force it."""
+    backend = request.config.getoption("--backend")
+    if not backend:
+        return
+
+    import orion.core.orion as orion_mod
+
+    original_setup = orion_mod.Scheme.setup_backend
+
+    def patched_setup(self, params):
+        params.orion_params.backend = backend
+        return original_setup(self, params)
+
+    orion_mod.Scheme.setup_backend = patched_setup

--- a/tests/oracle/assumptions.md
+++ b/tests/oracle/assumptions.md
@@ -1,0 +1,17 @@
+# Oracle Test Assumptions & Corrections
+
+Assumptions that were wrong when initially writing the tests, and the corrections discovered by running against the Lattigo backend.
+
+## 1. Rotation direction
+
+**Wrong assumption:** Positive `k` in `Rotate(ct, k)` means right-shift (last elements wrap to front).
+
+**Correct behavior:** Positive `k` = **left-shift**. `roll(1)` on `[1, 2, 3, 4]` gives `[2, 3, 4, 1]`. Negative `k` = right-shift.
+
+## 2. Monomial coefficient ordering
+
+**Wrong assumption:** `generate_monomial` takes ascending order `[a0, a1, ..., an]`.
+
+**Correct behavior:** `generate_monomial` takes **descending** order `[an, ..., a1, a0]`. The Python wrapper internally reverses (`coeffs[::-1]`) before passing to Go, which expects ascending. So the user-facing API is highest-degree-first, matching numpy's `poly1d` convention.
+
+Example: `f(x) = 2x + 1` → `generate_monomial([2.0, 1.0])`.

--- a/tests/oracle/conftest.py
+++ b/tests/oracle/conftest.py
@@ -1,0 +1,59 @@
+import sys
+import os
+
+import pytest
+import torch
+from orion.core.orion import Scheme
+
+# Make fhe_test_utils importable from within this package
+sys.path.insert(0, os.path.dirname(__file__))
+
+
+# ---------------------------------------------------------------------------
+# Minimal CKKS config for fast oracle tests.
+# LogN=13 (ring degree 8192), 4 levels (3 usable), 1 special prime.
+# This keeps key-gen fast while still supporting polynomial eval (degree ≤ 3)
+# and a few chained multiplications.
+# ---------------------------------------------------------------------------
+TEST_CKKS_CONFIG = {
+    "ckks_params": {
+        "LogN": 13,
+        "LogQ": [29, 26, 26, 26],
+        "LogP": [29],
+        "LogScale": 26,
+        "H": 8192,
+        "RingType": "ConjugateInvariant",
+    },
+    "orion": {
+        "backend": "lattigo",
+        "io_mode": "none",
+        "debug": False,
+    },
+}
+
+
+@pytest.fixture(scope="session")
+def scheme():
+    """Session-scoped Lattigo scheme shared by all tests."""
+    s = Scheme()
+    s.init_scheme(TEST_CKKS_CONFIG)
+    yield s
+    s.delete_scheme()
+
+
+@pytest.fixture(scope="session")
+def slots(scheme):
+    """Number of plaintext slots."""
+    return scheme.params.get_slots()
+
+
+@pytest.fixture(scope="session")
+def max_level(scheme):
+    """Maximum ciphertext level."""
+    return scheme.params.get_max_level()
+
+
+@pytest.fixture(scope="session")
+def default_scale(scheme):
+    """Default plaintext scale (2^LogScale)."""
+    return scheme.params.get_default_scale()

--- a/tests/oracle/fhe_test_utils.py
+++ b/tests/oracle/fhe_test_utils.py
@@ -1,0 +1,59 @@
+"""Shared utilities for FHE differential tests."""
+
+import torch
+
+
+def assert_fhe_close(actual, expected, atol=1e-2, rtol=0, msg=""):
+    """Compare FHE output against expected cleartext values.
+
+    Parameters
+    ----------
+    actual : torch.Tensor | list
+        Decrypted + decoded result from the FHE pipeline.
+    expected : torch.Tensor | list
+        Cleartext ground-truth values.
+    atol : float
+        Absolute tolerance (default 0.01 — generous for CKKS).
+    rtol : float
+        Relative tolerance.
+    msg : str
+        Optional message prepended to assertion errors.
+    """
+    if not isinstance(actual, torch.Tensor):
+        actual = torch.tensor(actual, dtype=torch.float64)
+    if not isinstance(expected, torch.Tensor):
+        expected = torch.tensor(expected, dtype=torch.float64)
+
+    actual = actual.double().flatten()
+    expected = expected.double().flatten()
+
+    # Trim to the shorter length (FHE may pad to slot boundary)
+    n = min(len(actual), len(expected))
+    actual = actual[:n]
+    expected = expected[:n]
+
+    diff = (actual - expected).abs()
+    tol = atol + rtol * expected.abs()
+    failures = diff > tol
+
+    if failures.any():
+        max_err_idx = diff.argmax().item()
+        detail = (
+            f"Max error: {diff[max_err_idx]:.6e} at index {max_err_idx} "
+            f"(actual={actual[max_err_idx]:.6f}, "
+            f"expected={expected[max_err_idx]:.6f}).  "
+            f"{failures.sum().item()}/{n} slots exceeded atol={atol}."
+        )
+        prefix = f"{msg}: " if msg else ""
+        raise AssertionError(f"{prefix}{detail}")
+
+
+def encrypt_values(scheme, values, level=None):
+    """Encode → encrypt a list of floats."""
+    ptxt = scheme.encode(values, level=level)
+    return scheme.encrypt(ptxt)
+
+
+def decrypt_values(scheme, ctxt):
+    """Decrypt → decode a CipherTensor back to torch.Tensor."""
+    return scheme.decode(scheme.decrypt(ctxt))

--- a/tests/oracle/test_bootstrap.py
+++ b/tests/oracle/test_bootstrap.py
@@ -1,0 +1,166 @@
+"""Tests for bootstrap (level refresh).
+
+Bootstrap requires larger parameters (LogN=16) and dedicated boot_logp,
+so these tests are significantly slower than the others. They are marked
+with @pytest.mark.slow and skipped by default.
+
+Run them explicitly with:  pytest -m slow tests/oracle/test_bootstrap.py
+
+The tests run against both backends. They mirror the prescale/postscale
+discipline implemented by ``orion.nn.operations.Bootstrap`` so they remain
+backend-agnostic: the backend is invoked at level 0 with values already in
+[-1, 1], matching the production contract.
+"""
+
+import math
+
+import pytest
+import torch
+from orion.core.orion import Scheme
+from fhe_test_utils import assert_fhe_close
+
+
+def _make_bootstrap_config(backend):
+    return {
+        "ckks_params": {
+            "LogN": 16,
+            "LogQ": [55, 40, 40, 40, 40, 40, 40, 40, 40, 40, 40],
+            "LogP": [61, 61, 61],
+            "LogScale": 40,
+            "H": 192,
+            "RingType": "Standard",
+        },
+        "boot_params": {
+            "LogP": [61, 61, 61, 61, 61, 61, 61, 61],
+        },
+        "orion": {
+            "backend": backend,
+            "io_mode": "none",
+            "debug": False,
+        },
+    }
+
+
+@pytest.fixture(scope="module", params=["lattigo", "desilo"])
+def boot_scheme(request):
+    """Module-scoped scheme with bootstrap support, one per backend."""
+    s = Scheme()
+    s.init_scheme(_make_bootstrap_config(request.param))
+    yield s
+    s.delete_scheme()
+
+
+def _normalize_and_bootstrap(scheme, ctxt, values, num_active_slots, margin=2.0):
+    """Mirror nn.operations.Bootstrap: shift + scale into [-1, 1], bootstrap,
+    then undo the scale and shift. Drives the backend at level 0 with
+    in-range values, which is the contract every Orion bootstrap caller
+    must satisfy.
+
+    The prescale is encoded as a *sparse* plaintext (zeros in unused slots).
+    Multiplying by it both scales the active slots and zeros out the slots
+    that the constant-add disturbed. Sparse bootstrap relies on those
+    inactive slots being zero, so a scalar-prescale variant breaks under
+    Lattigo's sparse path.
+    """
+    input_min = float(min(values))
+    input_max = float(max(values))
+
+    center = (input_min + input_max) / 2
+    half_range = (input_max - input_min) / 2
+    low = center - margin * half_range
+    high = center + margin * half_range
+
+    if high - low > 2:
+        postscale = math.ceil((high - low) / 2)
+        prescale = 1.0 / postscale
+    else:
+        postscale = 1
+        prescale = 1.0
+
+    constant = -(low + high) / 2
+
+    slots = scheme.params.get_slots()
+    prescale_vec = torch.zeros(slots, dtype=torch.float64)
+    prescale_vec[:num_active_slots] = prescale
+
+    if constant != 0:
+        ctxt = ctxt + constant
+
+    prescale_ptxt = scheme.encode(prescale_vec, level=ctxt.level())
+    ctxt = ctxt * prescale_ptxt
+
+    ctxt_btp = ctxt.bootstrap()
+
+    if postscale != 1:
+        ctxt_btp = ctxt_btp * postscale
+    if constant != 0:
+        ctxt_btp = ctxt_btp - constant
+
+    return ctxt_btp
+
+
+@pytest.mark.slow
+class TestBootstrap:
+
+    def test_bootstrap_restores_level(self, boot_scheme):
+        """After draining levels, bootstrap should restore them."""
+        scheme = boot_scheme
+        slots = scheme.params.get_slots()
+
+        # Generate a bootstrapper for the full slot count
+        scheme.bootstrapper.generate_bootstrapper(slots)
+
+        values = [float(i % 10) for i in range(slots)]
+        ptxt = scheme.encode(values)
+        ctxt = scheme.encrypt(ptxt)
+
+        # Drain levels via repeated float multiplications. The prescale
+        # multiply inside _normalize_and_bootstrap consumes the final level
+        # so the backend sees ct.level == 0.
+        max_level = scheme.params.get_max_level()
+        drained = list(values)
+        for _ in range(max_level - 1):
+            ctxt = ctxt * 1.1
+            drained = [v * 1.1 for v in drained]
+
+        level_before_btp = ctxt.level()
+        assert level_before_btp <= 1, (
+            f"Expected low level before bootstrap, got {level_before_btp}")
+
+        ctxt_btp = _normalize_and_bootstrap(scheme, ctxt, drained, slots)
+        level_after_btp = ctxt_btp.level()
+
+        assert level_after_btp > level_before_btp, (
+            f"Bootstrap should raise level: was {level_before_btp}, "
+            f"now {level_after_btp}")
+
+        result = scheme.decode(scheme.decrypt(ctxt_btp))
+
+        assert_fhe_close(
+            result, drained, atol=5e-1, msg="bootstrap values")
+
+    def test_bootstrap_sparse(self, boot_scheme):
+        """Sparse bootstrap (fewer slots than available)."""
+        scheme = boot_scheme
+        num_values = 64  # fewer than full slots
+
+        scheme.bootstrapper.generate_bootstrapper(num_values)
+
+        values = [float(i + 1) for i in range(num_values)]
+        ptxt = scheme.encode(values)
+        ctxt = scheme.encrypt(ptxt)
+
+        max_level = scheme.params.get_max_level()
+        drained = list(values)
+        for _ in range(max_level - 1):
+            ctxt = ctxt * 1.1
+            drained = [v * 1.1 for v in drained]
+
+        ctxt_btp = _normalize_and_bootstrap(scheme, ctxt, drained, num_values)
+        assert ctxt_btp.level() > 1
+
+        result = scheme.decode(scheme.decrypt(ctxt_btp))
+
+        assert_fhe_close(
+            result[:num_values], drained, atol=5e-1,
+            msg="sparse bootstrap values")

--- a/tests/oracle/test_encode_decode.py
+++ b/tests/oracle/test_encode_decode.py
@@ -1,0 +1,70 @@
+"""Tests for encode/decode round-trip accuracy."""
+
+import torch
+import pytest
+from fhe_test_utils import assert_fhe_close
+
+
+class TestEncodeDecode:
+    """Encode values into CKKS plaintexts and decode them back."""
+
+    def test_encode_decode_basic(self, scheme, slots):
+        """Encode a short vector, decode, check values match."""
+        values = [1.0, 2.0, 3.0, 4.0]
+        ptxt = scheme.encode(values)
+        result = scheme.decode(ptxt)
+        assert_fhe_close(result, values, atol=1e-4, msg="basic encode/decode")
+
+    def test_encode_decode_full_slots(self, scheme, slots):
+        """Encode a vector that fills all slots exactly."""
+        values = torch.randn(slots)
+        ptxt = scheme.encode(values)
+        result = scheme.decode(ptxt)
+        assert_fhe_close(result, values, atol=1e-4, msg="full-slot encode/decode")
+
+    def test_encode_decode_negative_values(self, scheme):
+        """Negative values round-trip correctly."""
+        values = [-3.5, -0.001, -100.0, 0.0]
+        ptxt = scheme.encode(values)
+        result = scheme.decode(ptxt)
+        assert_fhe_close(result, values, atol=1e-4, msg="negative values")
+
+    def test_encode_decode_large_values(self, scheme):
+        """Large magnitude values."""
+        values = [1e4, -1e4, 5e3, -5e3]
+        ptxt = scheme.encode(values)
+        result = scheme.decode(ptxt)
+        assert_fhe_close(result, values, atol=1.0, msg="large values")
+
+    def test_encode_decode_zeros(self, scheme, slots):
+        """All-zero vector."""
+        values = torch.zeros(slots)
+        ptxt = scheme.encode(values)
+        result = scheme.decode(ptxt)
+        assert_fhe_close(result, values, atol=1e-5, msg="zeros")
+
+    def test_encode_at_specific_level(self, scheme, max_level):
+        """Encode at a specific level and verify the plaintext level."""
+        values = [1.0, 2.0]
+        level = max_level - 2
+        ptxt = scheme.encode(values, level=level)
+        assert ptxt.level() == level, (
+            f"Expected plaintext level {level}, got {ptxt.level()}")
+        result = scheme.decode(ptxt)
+        assert_fhe_close(result, values, atol=1e-4, msg="specific level")
+
+    def test_encode_decode_tensor_shape_preserved(self, scheme):
+        """Output tensor shape matches input tensor shape."""
+        values = torch.randn(8)
+        ptxt = scheme.encode(values)
+        result = scheme.decode(ptxt)
+        assert result.shape == values.shape, (
+            f"Shape mismatch: {result.shape} vs {values.shape}")
+
+    def test_encode_decode_multi_plaintext(self, scheme, slots):
+        """Vector larger than one slot-count produces multiple plaintexts."""
+        values = torch.randn(slots * 2)
+        ptxt = scheme.encode(values)
+        assert len(ptxt) == 2, f"Expected 2 plaintexts, got {len(ptxt)}"
+        result = scheme.decode(ptxt)
+        assert_fhe_close(result, values, atol=1e-4, msg="multi-plaintext")

--- a/tests/oracle/test_encrypt_decrypt.py
+++ b/tests/oracle/test_encrypt_decrypt.py
@@ -1,0 +1,63 @@
+"""Tests for encrypt/decrypt round-trip accuracy."""
+
+import torch
+import pytest
+from fhe_test_utils import assert_fhe_close
+
+
+class TestEncryptDecrypt:
+    """Encrypt plaintexts into ciphertexts and decrypt them back."""
+
+    def test_encrypt_decrypt_basic(self, scheme):
+        """Basic encrypt → decrypt → decode round-trip."""
+        values = [1.0, 2.0, 3.0, 4.0]
+        ptxt = scheme.encode(values)
+        ctxt = scheme.encrypt(ptxt)
+        ptxt_out = scheme.decrypt(ctxt)
+        result = scheme.decode(ptxt_out)
+        assert_fhe_close(result, values, atol=1e-2, msg="basic encrypt/decrypt")
+
+    def test_encrypt_decrypt_full_slots(self, scheme, slots):
+        """Full-slot vector survives encrypt/decrypt."""
+        values = torch.randn(slots)
+        ptxt = scheme.encode(values)
+        ctxt = scheme.encrypt(ptxt)
+        ptxt_out = scheme.decrypt(ctxt)
+        result = scheme.decode(ptxt_out)
+        assert_fhe_close(result, values, atol=1e-2, msg="full-slot encrypt/decrypt")
+
+    def test_encrypt_decrypt_negative_values(self, scheme):
+        """Negative values survive encryption round-trip."""
+        values = [-5.0, -0.5, -0.001, 0.0]
+        ptxt = scheme.encode(values)
+        ctxt = scheme.encrypt(ptxt)
+        ptxt_out = scheme.decrypt(ctxt)
+        result = scheme.decode(ptxt_out)
+        assert_fhe_close(result, values, atol=1e-2, msg="negative encrypt/decrypt")
+
+    def test_ciphertext_level_matches_plaintext(self, scheme, max_level):
+        """Ciphertext level should equal the plaintext's encoding level."""
+        values = [1.0, 2.0]
+        level = max_level - 1
+        ptxt = scheme.encode(values, level=level)
+        ctxt = scheme.encrypt(ptxt)
+        assert ctxt.level() == level, (
+            f"Expected ctxt level {level}, got {ctxt.level()}")
+
+    def test_ciphertext_slots(self, scheme, slots):
+        """Ciphertext reports the correct number of slots."""
+        values = [1.0, 2.0]
+        ptxt = scheme.encode(values)
+        ctxt = scheme.encrypt(ptxt)
+        assert ctxt.slots() == slots, (
+            f"Expected {slots} slots, got {ctxt.slots()}")
+
+    def test_encrypt_decrypt_multi_ciphertext(self, scheme, slots):
+        """Multi-plaintext tensor encrypts to multi-ciphertext tensor."""
+        values = torch.randn(slots * 2)
+        ptxt = scheme.encode(values)
+        ctxt = scheme.encrypt(ptxt)
+        assert len(ctxt) == 2, f"Expected 2 ciphertexts, got {len(ctxt)}"
+        ptxt_out = scheme.decrypt(ctxt)
+        result = scheme.decode(ptxt_out)
+        assert_fhe_close(result, values, atol=1e-2, msg="multi-ciphertext")

--- a/tests/oracle/test_eval_ciphertext.py
+++ b/tests/oracle/test_eval_ciphertext.py
@@ -1,0 +1,130 @@
+"""Tests for ciphertext-ciphertext arithmetic (add, sub, mul)."""
+
+import torch
+import pytest
+from fhe_test_utils import assert_fhe_close, encrypt_values, decrypt_values
+
+
+class TestAddCiphertext:
+
+    def test_add_ciphertext(self, scheme):
+        a_vals = [1.0, 2.0, 3.0, 4.0]
+        b_vals = [10.0, 20.0, 30.0, 40.0]
+
+        ctxt_a = encrypt_values(scheme, a_vals)
+        ctxt_b = encrypt_values(scheme, b_vals)
+
+        ctxt_out = ctxt_a + ctxt_b
+        result = decrypt_values(scheme, ctxt_out)
+        expected = [a + b for a, b in zip(a_vals, b_vals)]
+        assert_fhe_close(result, expected, atol=1e-2, msg="add ciphertext")
+
+    def test_add_ciphertext_self(self, scheme):
+        """ct + ct should equal 2*ct."""
+        values = [1.0, 2.0, 3.0, 4.0]
+        ctxt = encrypt_values(scheme, values)
+
+        ctxt_out = ctxt + ctxt
+        result = decrypt_values(scheme, ctxt_out)
+        expected = [2 * v for v in values]
+        assert_fhe_close(result, expected, atol=1e-2, msg="add self")
+
+    def test_add_ciphertext_in_place(self, scheme):
+        a_vals = [1.0, 2.0, 3.0, 4.0]
+        b_vals = [10.0, 20.0, 30.0, 40.0]
+
+        ctxt_a = encrypt_values(scheme, a_vals)
+        ctxt_b = encrypt_values(scheme, b_vals)
+
+        ctxt_a += ctxt_b
+        result = decrypt_values(scheme, ctxt_a)
+        expected = [a + b for a, b in zip(a_vals, b_vals)]
+        assert_fhe_close(result, expected, atol=1e-2, msg="iadd ciphertext")
+
+
+class TestSubCiphertext:
+
+    def test_sub_ciphertext(self, scheme):
+        a_vals = [10.0, 20.0, 30.0, 40.0]
+        b_vals = [1.0, 2.0, 3.0, 4.0]
+
+        ctxt_a = encrypt_values(scheme, a_vals)
+        ctxt_b = encrypt_values(scheme, b_vals)
+
+        ctxt_out = ctxt_a - ctxt_b
+        result = decrypt_values(scheme, ctxt_out)
+        expected = [a - b for a, b in zip(a_vals, b_vals)]
+        assert_fhe_close(result, expected, atol=1e-2, msg="sub ciphertext")
+
+    def test_sub_ciphertext_self(self, scheme):
+        """ct - ct should be ~0."""
+        values = [1.0, 2.0, 3.0, 4.0]
+        ctxt = encrypt_values(scheme, values)
+
+        ctxt_out = ctxt - ctxt
+        result = decrypt_values(scheme, ctxt_out)
+        expected = [0.0] * len(values)
+        assert_fhe_close(result, expected, atol=1e-2, msg="sub self")
+
+    def test_sub_ciphertext_in_place(self, scheme):
+        a_vals = [10.0, 20.0, 30.0, 40.0]
+        b_vals = [1.0, 2.0, 3.0, 4.0]
+
+        ctxt_a = encrypt_values(scheme, a_vals)
+        ctxt_b = encrypt_values(scheme, b_vals)
+
+        ctxt_a -= ctxt_b
+        result = decrypt_values(scheme, ctxt_a)
+        expected = [a - b for a, b in zip(a_vals, b_vals)]
+        assert_fhe_close(result, expected, atol=1e-2, msg="isub ciphertext")
+
+
+class TestMulCiphertext:
+
+    def test_mul_ciphertext(self, scheme):
+        """Ciphertext * ciphertext (with relin + rescale)."""
+        a_vals = [1.0, 2.0, 3.0, 4.0]
+        b_vals = [2.0, 3.0, 4.0, 5.0]
+
+        ctxt_a = encrypt_values(scheme, a_vals)
+        ctxt_b = encrypt_values(scheme, b_vals)
+
+        ctxt_out = ctxt_a * ctxt_b
+        result = decrypt_values(scheme, ctxt_out)
+        expected = [a * b for a, b in zip(a_vals, b_vals)]
+        assert_fhe_close(result, expected, atol=1e-1, msg="mul ciphertext")
+
+    def test_mul_ciphertext_consumes_level(self, scheme, max_level):
+        """Mul + relin + rescale should drop level by 1."""
+        a_vals = [1.0, 2.0, 3.0, 4.0]
+        b_vals = [2.0, 3.0, 4.0, 5.0]
+
+        ctxt_a = encrypt_values(scheme, a_vals)
+        ctxt_b = encrypt_values(scheme, b_vals)
+        level_before = ctxt_a.level()
+
+        ctxt_out = ctxt_a * ctxt_b
+        assert ctxt_out.level() == level_before - 1, (
+            f"Expected level {level_before - 1}, got {ctxt_out.level()}")
+
+    def test_mul_ciphertext_square(self, scheme):
+        """ct * ct (squaring)."""
+        values = [1.0, 2.0, 3.0, 4.0]
+        ctxt = encrypt_values(scheme, values)
+
+        ctxt_out = ctxt * ctxt
+        result = decrypt_values(scheme, ctxt_out)
+        expected = [v * v for v in values]
+        assert_fhe_close(result, expected, atol=1e-1, msg="square")
+
+    def test_mul_ciphertext_in_place(self, scheme):
+        a_vals = [1.0, 2.0, 3.0, 4.0]
+        b_vals = [2.0, 3.0, 4.0, 5.0]
+
+        ctxt_a = encrypt_values(scheme, a_vals)
+        ctxt_b = encrypt_values(scheme, b_vals)
+
+        ctxt_a *= ctxt_b
+        result = decrypt_values(scheme, ctxt_a)
+        expected = [a * b for a, b in zip(a_vals, b_vals)]
+        assert_fhe_close(result, expected, atol=1e-1, msg="imul ciphertext")

--- a/tests/oracle/test_eval_plaintext.py
+++ b/tests/oracle/test_eval_plaintext.py
@@ -1,0 +1,114 @@
+"""Tests for plaintext-ciphertext arithmetic (add, sub, mul)."""
+
+import torch
+import pytest
+from fhe_test_utils import assert_fhe_close, encrypt_values, decrypt_values
+
+
+class TestAddPlaintext:
+
+    def test_add_plaintext(self, scheme, max_level):
+        a_vals = [1.0, 2.0, 3.0, 4.0]
+        b_vals = [10.0, 20.0, 30.0, 40.0]
+
+        ctxt_a = encrypt_values(scheme, a_vals)
+        ptxt_b = scheme.encode(b_vals)
+
+        ctxt_out = ctxt_a + ptxt_b
+        result = decrypt_values(scheme, ctxt_out)
+        expected = [a + b for a, b in zip(a_vals, b_vals)]
+        assert_fhe_close(result, expected, atol=1e-2, msg="add plaintext")
+
+    def test_add_plaintext_negative(self, scheme):
+        a_vals = [5.0, 10.0, 15.0, 20.0]
+        b_vals = [-5.0, -10.0, -15.0, -20.0]
+
+        ctxt_a = encrypt_values(scheme, a_vals)
+        ptxt_b = scheme.encode(b_vals)
+
+        ctxt_out = ctxt_a + ptxt_b
+        result = decrypt_values(scheme, ctxt_out)
+        expected = [0.0, 0.0, 0.0, 0.0]
+        assert_fhe_close(result, expected, atol=1e-2, msg="add plaintext cancel")
+
+    def test_add_plaintext_in_place(self, scheme):
+        a_vals = [1.0, 2.0, 3.0, 4.0]
+        b_vals = [10.0, 20.0, 30.0, 40.0]
+
+        ctxt_a = encrypt_values(scheme, a_vals)
+        ptxt_b = scheme.encode(b_vals)
+
+        ctxt_a += ptxt_b
+        result = decrypt_values(scheme, ctxt_a)
+        expected = [a + b for a, b in zip(a_vals, b_vals)]
+        assert_fhe_close(result, expected, atol=1e-2, msg="iadd plaintext")
+
+
+class TestSubPlaintext:
+
+    def test_sub_plaintext(self, scheme):
+        a_vals = [10.0, 20.0, 30.0, 40.0]
+        b_vals = [1.0, 2.0, 3.0, 4.0]
+
+        ctxt_a = encrypt_values(scheme, a_vals)
+        ptxt_b = scheme.encode(b_vals)
+
+        ctxt_out = ctxt_a - ptxt_b
+        result = decrypt_values(scheme, ctxt_out)
+        expected = [a - b for a, b in zip(a_vals, b_vals)]
+        assert_fhe_close(result, expected, atol=1e-2, msg="sub plaintext")
+
+    def test_sub_plaintext_in_place(self, scheme):
+        a_vals = [10.0, 20.0, 30.0, 40.0]
+        b_vals = [1.0, 2.0, 3.0, 4.0]
+
+        ctxt_a = encrypt_values(scheme, a_vals)
+        ptxt_b = scheme.encode(b_vals)
+
+        ctxt_a -= ptxt_b
+        result = decrypt_values(scheme, ctxt_a)
+        expected = [a - b for a, b in zip(a_vals, b_vals)]
+        assert_fhe_close(result, expected, atol=1e-2, msg="isub plaintext")
+
+
+class TestMulPlaintext:
+
+    def test_mul_plaintext(self, scheme):
+        """Ciphertext * plaintext, consumes one level (rescale)."""
+        a_vals = [1.0, 2.0, 3.0, 4.0]
+        b_vals = [2.0, 3.0, 4.0, 5.0]
+
+        ctxt_a = encrypt_values(scheme, a_vals)
+        ptxt_b = scheme.encode(b_vals)
+
+        ctxt_out = ctxt_a * ptxt_b
+        result = decrypt_values(scheme, ctxt_out)
+        expected = [a * b for a, b in zip(a_vals, b_vals)]
+        assert_fhe_close(result, expected, atol=1e-1, msg="mul plaintext")
+
+    def test_mul_plaintext_consumes_level(self, scheme, max_level):
+        """MulPlaintext + rescale should drop the ciphertext level by 1."""
+        a_vals = [1.0, 2.0, 3.0, 4.0]
+        b_vals = [2.0, 3.0, 4.0, 5.0]
+
+        ctxt_a = encrypt_values(scheme, a_vals)
+        level_before = ctxt_a.level()
+
+        ptxt_b = scheme.encode(b_vals)
+        ctxt_out = ctxt_a * ptxt_b
+
+        assert ctxt_out.level() == level_before - 1, (
+            f"Expected level {level_before - 1} after mul+rescale, "
+            f"got {ctxt_out.level()}")
+
+    def test_mul_plaintext_in_place(self, scheme):
+        a_vals = [1.0, 2.0, 3.0, 4.0]
+        b_vals = [2.0, 3.0, 4.0, 5.0]
+
+        ctxt_a = encrypt_values(scheme, a_vals)
+        ptxt_b = scheme.encode(b_vals)
+
+        ctxt_a *= ptxt_b
+        result = decrypt_values(scheme, ctxt_a)
+        expected = [a * b for a, b in zip(a_vals, b_vals)]
+        assert_fhe_close(result, expected, atol=1e-1, msg="imul plaintext")

--- a/tests/oracle/test_eval_rescale.py
+++ b/tests/oracle/test_eval_rescale.py
@@ -1,0 +1,101 @@
+"""Tests for rescale and scale/level metadata management."""
+
+import torch
+import pytest
+from fhe_test_utils import assert_fhe_close, encrypt_values, decrypt_values
+
+
+class TestRescale:
+
+    def test_rescale_drops_level(self, scheme, max_level):
+        """Manual rescale should drop the ciphertext level by 1."""
+        values = [1.0, 2.0, 3.0, 4.0]
+        ctxt = encrypt_values(scheme, values)
+        level_before = ctxt.level()
+
+        # MulScalarFloat triggers an automatic rescale, but we can also
+        # test it via the evaluator directly after a plaintext multiply
+        # that does NOT auto-rescale. We'll use the backend directly.
+        ctxt_id = scheme.backend.MulScalarFloatNew(ctxt.ids[0], 2.0)
+        # Now manually rescale
+        ctxt_id = scheme.backend.Rescale(ctxt_id)
+
+        level_after = scheme.backend.GetCiphertextLevel(ctxt_id)
+        assert level_after == level_before - 1, (
+            f"Expected level {level_before - 1} after rescale, got {level_after}")
+
+
+class TestScaleManagement:
+
+    def test_get_ciphertext_scale(self, scheme, default_scale):
+        """Freshly encrypted ciphertext should have the default scale."""
+        values = [1.0, 2.0]
+        ctxt = encrypt_values(scheme, values)
+        scale = ctxt.scale()
+        assert scale == default_scale, (
+            f"Expected scale {default_scale}, got {scale}")
+
+    def test_set_ciphertext_scale(self, scheme, default_scale):
+        """Setting scale should be reflected when queried."""
+        values = [1.0, 2.0]
+        ctxt = encrypt_values(scheme, values)
+        new_scale = default_scale * 2
+        ctxt.set_scale(new_scale)
+        assert ctxt.scale() == new_scale, (
+            f"Expected scale {new_scale}, got {ctxt.scale()}")
+
+    def test_get_plaintext_scale(self, scheme, default_scale):
+        """Freshly encoded plaintext should have the default scale."""
+        values = [1.0, 2.0]
+        ptxt = scheme.encode(values)
+        scale = ptxt.scale()
+        assert scale == default_scale, (
+            f"Expected scale {default_scale}, got {scale}")
+
+    def test_set_plaintext_scale(self, scheme, default_scale):
+        """Setting plaintext scale should be reflected when queried."""
+        values = [1.0, 2.0]
+        ptxt = scheme.encode(values)
+        new_scale = default_scale * 2
+        ptxt.set_scale(new_scale)
+        assert ptxt.scale() == new_scale, (
+            f"Expected scale {new_scale}, got {ptxt.scale()}")
+
+
+class TestLevelManagement:
+
+    def test_level_decreases_after_mul_float_scalar(self, scheme, max_level):
+        """MulScalarFloat (which auto-rescales) should drop level by 1."""
+        values = [1.0, 2.0, 3.0, 4.0]
+        ctxt = encrypt_values(scheme, values)
+        level_before = ctxt.level()
+        ctxt_out = ctxt * 2.5  # float triggers rescale
+        assert ctxt_out.level() == level_before - 1
+
+    def test_level_stable_after_add(self, scheme, max_level):
+        """Addition should not change the ciphertext level."""
+        values = [1.0, 2.0, 3.0, 4.0]
+        ctxt = encrypt_values(scheme, values)
+        level_before = ctxt.level()
+        ctxt_out = ctxt + 5.0
+        assert ctxt_out.level() == level_before
+
+    def test_level_stable_after_int_mul(self, scheme, max_level):
+        """MulScalarInt should not change the ciphertext level."""
+        values = [1.0, 2.0, 3.0, 4.0]
+        ctxt = encrypt_values(scheme, values)
+        level_before = ctxt.level()
+        ctxt_out = ctxt * 3  # int, no rescale
+        assert ctxt_out.level() == level_before
+
+    def test_successive_muls_drain_levels(self, scheme, max_level):
+        """Chained float multiplies should drain levels one at a time."""
+        values = [1.0, 2.0, 3.0, 4.0]
+        ctxt = encrypt_values(scheme, values)
+
+        for i in range(max_level - 1):
+            ctxt = ctxt * 1.5  # each costs 1 level
+            expected_level = max_level - (i + 1)
+            assert ctxt.level() == expected_level, (
+                f"After {i+1} muls: expected level {expected_level}, "
+                f"got {ctxt.level()}")

--- a/tests/oracle/test_eval_rotate.py
+++ b/tests/oracle/test_eval_rotate.py
@@ -1,0 +1,91 @@
+"""Tests for rotation and negation on ciphertexts."""
+
+import torch
+import pytest
+from fhe_test_utils import assert_fhe_close, encrypt_values, decrypt_values
+
+
+class TestNegate:
+
+    def test_negate(self, scheme):
+        values = [1.0, -2.0, 3.0, -4.0]
+        ctxt = encrypt_values(scheme, values)
+        ctxt_out = -ctxt
+        result = decrypt_values(scheme, ctxt_out)
+        expected = [-v for v in values]
+        assert_fhe_close(result, expected, atol=1e-2, msg="negate")
+
+    def test_double_negate(self, scheme):
+        """Negating twice should return original values."""
+        values = [1.0, -2.0, 3.0, -4.0]
+        ctxt = encrypt_values(scheme, values)
+        ctxt_out = -(-ctxt)
+        result = decrypt_values(scheme, ctxt_out)
+        assert_fhe_close(result, values, atol=1e-2, msg="double negate")
+
+
+class TestRotate:
+
+    def test_rotate_left_1(self, scheme, slots):
+        """Rotate left by 1 (positive k = left-shift in Lattigo CKKS)."""
+        values = list(range(1, slots + 1))
+        values = [float(v) for v in values]
+        ctxt = encrypt_values(scheme, values)
+
+        scheme.evaluator.add_rotation_key(1)
+        ctxt_out = ctxt.roll(1)
+        result = decrypt_values(scheme, ctxt_out)
+
+        # Cyclic left-shift by 1: first element wraps to end
+        expected = values[1:] + [values[0]]
+        assert_fhe_close(result, expected, atol=1e-2, msg="rotate left 1")
+
+    def test_rotate_right_1(self, scheme, slots):
+        """Rotate right by 1 (negative k = right-shift)."""
+        values = list(range(1, slots + 1))
+        values = [float(v) for v in values]
+        ctxt = encrypt_values(scheme, values)
+
+        scheme.evaluator.add_rotation_key(-1)
+        ctxt_out = ctxt.roll(-1)
+        result = decrypt_values(scheme, ctxt_out)
+
+        # Cyclic right-shift by 1: last element wraps to front
+        expected = [values[-1]] + values[:-1]
+        assert_fhe_close(result, expected, atol=1e-2, msg="rotate right 1")
+
+    def test_rotate_by_n(self, scheme, slots):
+        """Rotate by n positions (left-shift)."""
+        n = 4
+        values = list(range(1, slots + 1))
+        values = [float(v) for v in values]
+        ctxt = encrypt_values(scheme, values)
+
+        scheme.evaluator.add_rotation_key(n)
+        ctxt_out = ctxt.roll(n)
+        result = decrypt_values(scheme, ctxt_out)
+
+        # Cyclic left-shift by n
+        expected = values[n:] + values[:n]
+        assert_fhe_close(result, expected, atol=1e-2, msg=f"rotate left {n}")
+
+    def test_rotate_full_cycle(self, scheme, slots):
+        """Rotating by the full slot count should return original."""
+        values = list(range(1, slots + 1))
+        values = [float(v) for v in values]
+        ctxt = encrypt_values(scheme, values)
+
+        scheme.evaluator.add_rotation_key(slots)
+        ctxt_out = ctxt.roll(slots)
+        result = decrypt_values(scheme, ctxt_out)
+        assert_fhe_close(result, values, atol=1e-2, msg="rotate full cycle")
+
+    def test_rotate_zero(self, scheme, slots):
+        """Rotating by 0 is a no-op."""
+        values = [1.0, 2.0, 3.0, 4.0]
+        ctxt = encrypt_values(scheme, values)
+
+        scheme.evaluator.add_rotation_key(0)
+        ctxt_out = ctxt.roll(0)
+        result = decrypt_values(scheme, ctxt_out)
+        assert_fhe_close(result, values, atol=1e-2, msg="rotate 0")

--- a/tests/oracle/test_eval_scalar.py
+++ b/tests/oracle/test_eval_scalar.py
@@ -1,0 +1,109 @@
+"""Tests for scalar arithmetic on ciphertexts (add, sub, mul)."""
+
+import torch
+import pytest
+from fhe_test_utils import assert_fhe_close, encrypt_values, decrypt_values
+
+
+class TestAddScalar:
+
+    def test_add_scalar_positive(self, scheme):
+        values = [1.0, 2.0, 3.0, 4.0]
+        ctxt = encrypt_values(scheme, values)
+        ctxt_out = ctxt + 5.0
+        result = decrypt_values(scheme, ctxt_out)
+        expected = [v + 5.0 for v in values]
+        assert_fhe_close(result, expected, atol=1e-2, msg="add scalar +5")
+
+    def test_add_scalar_negative(self, scheme):
+        values = [1.0, 2.0, 3.0, 4.0]
+        ctxt = encrypt_values(scheme, values)
+        ctxt_out = ctxt + (-3.0)
+        result = decrypt_values(scheme, ctxt_out)
+        expected = [v - 3.0 for v in values]
+        assert_fhe_close(result, expected, atol=1e-2, msg="add scalar -3")
+
+    def test_add_scalar_zero(self, scheme):
+        values = [1.0, 2.0, 3.0, 4.0]
+        ctxt = encrypt_values(scheme, values)
+        ctxt_out = ctxt + 0.0
+        result = decrypt_values(scheme, ctxt_out)
+        assert_fhe_close(result, values, atol=1e-2, msg="add scalar 0")
+
+    def test_add_scalar_in_place(self, scheme):
+        values = [1.0, 2.0, 3.0, 4.0]
+        ctxt = encrypt_values(scheme, values)
+        ctxt += 5.0
+        result = decrypt_values(scheme, ctxt)
+        expected = [v + 5.0 for v in values]
+        assert_fhe_close(result, expected, atol=1e-2, msg="iadd scalar")
+
+
+class TestSubScalar:
+
+    def test_sub_scalar_positive(self, scheme):
+        values = [10.0, 20.0, 30.0, 40.0]
+        ctxt = encrypt_values(scheme, values)
+        ctxt_out = ctxt - 5.0
+        result = decrypt_values(scheme, ctxt_out)
+        expected = [v - 5.0 for v in values]
+        assert_fhe_close(result, expected, atol=1e-2, msg="sub scalar 5")
+
+    def test_sub_scalar_negative(self, scheme):
+        values = [1.0, 2.0, 3.0, 4.0]
+        ctxt = encrypt_values(scheme, values)
+        ctxt_out = ctxt - (-2.0)
+        result = decrypt_values(scheme, ctxt_out)
+        expected = [v + 2.0 for v in values]
+        assert_fhe_close(result, expected, atol=1e-2, msg="sub scalar -2")
+
+    def test_sub_scalar_in_place(self, scheme):
+        values = [10.0, 20.0, 30.0, 40.0]
+        ctxt = encrypt_values(scheme, values)
+        ctxt -= 5.0
+        result = decrypt_values(scheme, ctxt)
+        expected = [v - 5.0 for v in values]
+        assert_fhe_close(result, expected, atol=1e-2, msg="isub scalar")
+
+
+class TestMulScalar:
+
+    def test_mul_scalar_float(self, scheme):
+        values = [1.0, 2.0, 3.0, 4.0]
+        ctxt = encrypt_values(scheme, values)
+        ctxt_out = ctxt * 2.5
+        result = decrypt_values(scheme, ctxt_out)
+        expected = [v * 2.5 for v in values]
+        assert_fhe_close(result, expected, atol=1e-1, msg="mul scalar float 2.5")
+
+    def test_mul_scalar_int(self, scheme):
+        values = [1.0, 2.0, 3.0, 4.0]
+        ctxt = encrypt_values(scheme, values)
+        ctxt_out = ctxt * 3
+        result = decrypt_values(scheme, ctxt_out)
+        expected = [v * 3 for v in values]
+        assert_fhe_close(result, expected, atol=1e-2, msg="mul scalar int 3")
+
+    def test_mul_scalar_negative(self, scheme):
+        values = [1.0, 2.0, 3.0, 4.0]
+        ctxt = encrypt_values(scheme, values)
+        ctxt_out = ctxt * (-2.0)
+        result = decrypt_values(scheme, ctxt_out)
+        expected = [v * -2.0 for v in values]
+        assert_fhe_close(result, expected, atol=1e-1, msg="mul scalar -2")
+
+    def test_mul_scalar_one(self, scheme):
+        """Multiplying by 1 (int) should be a no-op."""
+        values = [1.0, 2.0, 3.0, 4.0]
+        ctxt = encrypt_values(scheme, values)
+        ctxt_out = ctxt * 1
+        result = decrypt_values(scheme, ctxt_out)
+        assert_fhe_close(result, values, atol=1e-2, msg="mul scalar 1")
+
+    def test_mul_scalar_in_place(self, scheme):
+        values = [1.0, 2.0, 3.0, 4.0]
+        ctxt = encrypt_values(scheme, values)
+        ctxt *= 2.5
+        result = decrypt_values(scheme, ctxt)
+        expected = [v * 2.5 for v in values]
+        assert_fhe_close(result, expected, atol=1e-1, msg="imul scalar")

--- a/tests/oracle/test_linear_transform.py
+++ b/tests/oracle/test_linear_transform.py
@@ -1,0 +1,121 @@
+"""Tests for linear transform (diagonal matrix-vector multiply)."""
+
+import torch
+import pytest
+from fhe_test_utils import assert_fhe_close, encrypt_values, decrypt_values
+
+
+class TestLinearTransform:
+
+    def test_identity_transform(self, scheme, slots, max_level):
+        """A diagonal matrix with all 1s on the main diagonal = identity."""
+        values = [float(i + 1) for i in range(slots)]
+        level = max_level
+
+        # Identity: single diagonal at index 0, all ones
+        diags_idxs = [0]
+        diags_data = [1.0] * slots
+
+        lt_id = scheme.backend.GenerateLinearTransform(
+            diags_idxs, diags_data, level, 1.0, "none")
+
+        # Generate rotation keys for this transform
+        rot_keys = scheme.backend.GetLinearTransformRotationKeys(lt_id)
+        for key in rot_keys:
+            scheme.backend.GenerateLinearTransformRotationKey(key)
+
+        ctxt = encrypt_values(scheme, values, level=level)
+        ctxt_out_id = scheme.backend.EvaluateLinearTransform(lt_id, ctxt.ids[0])
+
+        # Rescale after linear transform
+        ctxt_out_id = scheme.backend.Rescale(ctxt_out_id)
+
+        # Decrypt the raw ciphertext ID
+        ptxt_out_id = scheme.backend.Decrypt(ctxt_out_id)
+        result = scheme.backend.Decode(ptxt_out_id)
+
+        assert_fhe_close(result, values, atol=1e-1, msg="identity transform")
+        scheme.backend.DeleteLinearTransform(lt_id)
+
+    def test_scale_by_constant(self, scheme, slots, max_level):
+        """Diagonal matrix with constant c on the main diagonal = c * x."""
+        values = [float(i + 1) for i in range(slots)]
+        c = 3.0
+        level = max_level
+
+        diags_idxs = [0]
+        diags_data = [c] * slots
+
+        lt_id = scheme.backend.GenerateLinearTransform(
+            diags_idxs, diags_data, level, 1.0, "none")
+
+        rot_keys = scheme.backend.GetLinearTransformRotationKeys(lt_id)
+        for key in rot_keys:
+            scheme.backend.GenerateLinearTransformRotationKey(key)
+
+        ctxt = encrypt_values(scheme, values, level=level)
+        ctxt_out_id = scheme.backend.EvaluateLinearTransform(lt_id, ctxt.ids[0])
+        ctxt_out_id = scheme.backend.Rescale(ctxt_out_id)
+
+        ptxt_out_id = scheme.backend.Decrypt(ctxt_out_id)
+        result = scheme.backend.Decode(ptxt_out_id)
+
+        expected = [c * v for v in values]
+        assert_fhe_close(result, expected, atol=5e-1, msg="scale transform")
+        scheme.backend.DeleteLinearTransform(lt_id)
+
+    def test_cyclic_permutation(self, scheme, slots, max_level):
+        """A single diagonal at index k = cyclic shift by k positions."""
+        values = [float(i + 1) for i in range(slots)]
+        k = 3
+        level = max_level
+
+        diags_idxs = [k]
+        diags_data = [1.0] * slots
+
+        lt_id = scheme.backend.GenerateLinearTransform(
+            diags_idxs, diags_data, level, 1.0, "none")
+
+        rot_keys = scheme.backend.GetLinearTransformRotationKeys(lt_id)
+        for key in rot_keys:
+            scheme.backend.GenerateLinearTransformRotationKey(key)
+
+        ctxt = encrypt_values(scheme, values, level=level)
+        ctxt_out_id = scheme.backend.EvaluateLinearTransform(lt_id, ctxt.ids[0])
+        ctxt_out_id = scheme.backend.Rescale(ctxt_out_id)
+
+        ptxt_out_id = scheme.backend.Decrypt(ctxt_out_id)
+        result = scheme.backend.Decode(ptxt_out_id)
+
+        # Diagonal at index k means output[i] = diag[i] * input[(i+k) mod n]
+        expected = [values[(i + k) % slots] for i in range(slots)]
+        assert_fhe_close(result, expected, atol=1e-1, msg=f"permute by {k}")
+        scheme.backend.DeleteLinearTransform(lt_id)
+
+    def test_multi_diagonal(self, scheme, slots, max_level):
+        """Sum of two diagonals: identity + shift-by-1."""
+        values = [float(i + 1) for i in range(slots)]
+        level = max_level
+
+        # Diagonal 0 (identity) + diagonal 1 (shift by 1)
+        diags_idxs = [0, 1]
+        diags_data = [1.0] * slots + [1.0] * slots  # flattened
+
+        lt_id = scheme.backend.GenerateLinearTransform(
+            diags_idxs, diags_data, level, 1.0, "none")
+
+        rot_keys = scheme.backend.GetLinearTransformRotationKeys(lt_id)
+        for key in rot_keys:
+            scheme.backend.GenerateLinearTransformRotationKey(key)
+
+        ctxt = encrypt_values(scheme, values, level=level)
+        ctxt_out_id = scheme.backend.EvaluateLinearTransform(lt_id, ctxt.ids[0])
+        ctxt_out_id = scheme.backend.Rescale(ctxt_out_id)
+
+        ptxt_out_id = scheme.backend.Decrypt(ctxt_out_id)
+        result = scheme.backend.Decode(ptxt_out_id)
+
+        # output[i] = input[i] + input[(i+1) mod n]
+        expected = [values[i] + values[(i + 1) % slots] for i in range(slots)]
+        assert_fhe_close(result, expected, atol=5e-1, msg="multi-diagonal")
+        scheme.backend.DeleteLinearTransform(lt_id)

--- a/tests/oracle/test_poly_eval.py
+++ b/tests/oracle/test_poly_eval.py
@@ -1,0 +1,116 @@
+"""Tests for polynomial evaluation (monomial and Chebyshev basis)."""
+
+import math
+import torch
+import numpy as np
+import pytest
+from fhe_test_utils import assert_fhe_close, encrypt_values, decrypt_values
+
+
+class TestMonomialPolynomial:
+
+    def test_monomial_linear(self, scheme, max_level):
+        """Evaluate f(x) = 2x + 1 (degree-1 monomial).
+
+        generate_monomial takes descending order: [a_n, ..., a_1, a_0].
+        So [2, 1] means f(x) = 2x + 1.
+        """
+        coeffs = [2.0, 1.0]  # descending: a1=2, a0=1 -> f(x) = 2x + 1
+        poly_id = scheme.poly_evaluator.generate_monomial(coeffs)
+
+        values = [0.5, 1.0, -0.5, 0.0]
+        ctxt = encrypt_values(scheme, values)
+        ctxt_out = scheme.poly_evaluator.evaluate_polynomial(ctxt, poly_id)
+        result = decrypt_values(scheme, ctxt_out)
+
+        expected = [2.0 * v + 1.0 for v in values]
+        assert_fhe_close(result, expected, atol=1e-1, msg="monomial linear")
+
+    def test_monomial_quadratic(self, scheme, max_level):
+        """Evaluate f(x) = x^2 + x + 1.
+
+        Descending: [a2, a1, a0] = [1, 1, 1].
+        """
+        coeffs = [1.0, 1.0, 1.0]  # descending: a2=1, a1=1, a0=1
+        poly_id = scheme.poly_evaluator.generate_monomial(coeffs)
+
+        values = [0.5, 1.0, -0.5, 0.0]
+        ctxt = encrypt_values(scheme, values)
+        ctxt_out = scheme.poly_evaluator.evaluate_polynomial(ctxt, poly_id)
+        result = decrypt_values(scheme, ctxt_out)
+
+        expected = [v**2 + v + 1.0 for v in values]
+        assert_fhe_close(result, expected, atol=1e-1, msg="monomial quadratic")
+
+    def test_monomial_cubic(self, scheme, max_level):
+        """Evaluate f(x) = x^3 - x (odd function).
+
+        Descending: [a3, a2, a1, a0] = [1, 0, -1, 0].
+        """
+        coeffs = [1.0, 0.0, -1.0, 0.0]  # descending: a3=1, a2=0, a1=-1, a0=0
+        poly_id = scheme.poly_evaluator.generate_monomial(coeffs)
+
+        values = [0.25, 0.5, -0.25, -0.5]
+        ctxt = encrypt_values(scheme, values)
+        ctxt_out = scheme.poly_evaluator.evaluate_polynomial(ctxt, poly_id)
+        result = decrypt_values(scheme, ctxt_out)
+
+        expected = [v**3 - v for v in values]
+        assert_fhe_close(result, expected, atol=1e-1, msg="monomial cubic")
+
+
+class TestChebyshevPolynomial:
+
+    def test_chebyshev_degree2(self, scheme, max_level):
+        """Evaluate a degree-2 Chebyshev polynomial.
+
+        T0(x) = 1, T1(x) = x, T2(x) = 2x^2 - 1
+        Coeffs [c0, c1, c2] means f(x) = c0*T0 + c1*T1 + c2*T2
+        With [1, 0, 1]: f(x) = 1 + (2x^2 - 1) = 2x^2
+        """
+        coeffs = [1.0, 0.0, 1.0]
+        poly_id = scheme.poly_evaluator.generate_chebyshev(coeffs)
+
+        values = [0.25, 0.5, -0.25, -0.5]
+        ctxt = encrypt_values(scheme, values)
+        ctxt_out = scheme.poly_evaluator.evaluate_polynomial(ctxt, poly_id)
+        result = decrypt_values(scheme, ctxt_out)
+
+        expected = [2.0 * v**2 for v in values]
+        assert_fhe_close(result, expected, atol=1e-1, msg="chebyshev deg-2")
+
+    def test_chebyshev_identity(self, scheme, max_level):
+        """T1(x) = x, so coeffs [0, 1] should give back x."""
+        coeffs = [0.0, 1.0]
+        poly_id = scheme.poly_evaluator.generate_chebyshev(coeffs)
+
+        values = [0.1, 0.5, -0.3, 0.9]
+        ctxt = encrypt_values(scheme, values)
+        ctxt_out = scheme.poly_evaluator.evaluate_polynomial(ctxt, poly_id)
+        result = decrypt_values(scheme, ctxt_out)
+
+        assert_fhe_close(result, values, atol=1e-1, msg="chebyshev identity")
+
+
+class TestMinimaxSign:
+
+    def test_minimax_sign_returns_coeffs(self, scheme):
+        """generate_minimax_sign_coeffs should return coefficient tensors."""
+        degrees = [7]
+        coeffs_list = scheme.poly_evaluator.generate_minimax_sign_coeffs(
+            degrees, prec=64, logalpha=6, logerr=6)
+
+        assert len(coeffs_list) == 1, (
+            f"Expected 1 set of coefficients, got {len(coeffs_list)}")
+        assert len(coeffs_list[0]) == 8, (
+            f"Degree-7 poly should have 8 coefficients, got {len(coeffs_list[0])}")
+
+    def test_minimax_sign_multi_degree(self, scheme):
+        """Multiple degrees should return one tensor per degree."""
+        degrees = [3, 5]
+        coeffs_list = scheme.poly_evaluator.generate_minimax_sign_coeffs(
+            degrees, prec=64, logalpha=6, logerr=6)
+
+        assert len(coeffs_list) == 2
+        assert len(coeffs_list[0]) == 4  # degree 3 -> 4 coeffs
+        assert len(coeffs_list[1]) == 6  # degree 5 -> 6 coeffs

--- a/tests/test_bsgs_linear_transform.py
+++ b/tests/test_bsgs_linear_transform.py
@@ -1,0 +1,280 @@
+"""Tests for BSGS-optimized linear transform evaluation.
+
+These mirror the oracle linear transform tests but pass bsgs_ratio=2
+to exercise the Baby-step Giant-step path in the DeSiLo backend.
+"""
+
+import sys
+import os
+import torch
+import pytest
+
+from orion.core.orion import Scheme
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "oracle"))
+from fhe_test_utils import assert_fhe_close, encrypt_values
+
+
+TEST_CKKS_CONFIG = {
+    "ckks_params": {
+        "LogN": 13,
+        "LogQ": [29, 26, 26, 26],
+        "LogP": [29],
+        "LogScale": 26,
+        "H": 8192,
+        "RingType": "ConjugateInvariant",
+    },
+    "orion": {
+        "backend": "desilo",
+        "io_mode": "none",
+        "debug": False,
+    },
+}
+
+BSGS_RATIO = 2
+
+
+@pytest.fixture(scope="module")
+def scheme():
+    s = Scheme()
+    s.init_scheme(TEST_CKKS_CONFIG)
+    yield s
+    s.delete_scheme()
+
+
+@pytest.fixture(scope="module")
+def slots(scheme):
+    return scheme.params.get_slots()
+
+
+@pytest.fixture(scope="module")
+def max_level(scheme):
+    return scheme.params.get_max_level()
+
+
+class TestBSGSLinearTransform:
+
+    def test_identity_bsgs(self, scheme, slots, max_level):
+        """Identity transform via BSGS should return input unchanged."""
+        values = [float(i + 1) for i in range(slots)]
+        level = max_level
+
+        diags_idxs = [0]
+        diags_data = [1.0] * slots
+
+        lt_id = scheme.backend.GenerateLinearTransform(
+            diags_idxs, diags_data, level, BSGS_RATIO, "none")
+
+        ctxt = encrypt_values(scheme, values, level=level)
+        ctxt_out_id = scheme.backend.EvaluateLinearTransform(
+            lt_id, ctxt.ids[0])
+        ctxt_out_id = scheme.backend.Rescale(ctxt_out_id)
+
+        ptxt_out_id = scheme.backend.Decrypt(ctxt_out_id)
+        result = scheme.backend.Decode(ptxt_out_id)
+
+        assert_fhe_close(result, values, atol=1e-1,
+                         msg="BSGS identity transform")
+        scheme.backend.DeleteLinearTransform(lt_id)
+
+    def test_scale_by_constant_bsgs(self, scheme, slots, max_level):
+        """Scale transform via BSGS: result = c * input."""
+        values = [float(i + 1) for i in range(slots)]
+        c = 3.0
+        level = max_level
+
+        diags_idxs = [0]
+        diags_data = [c] * slots
+
+        lt_id = scheme.backend.GenerateLinearTransform(
+            diags_idxs, diags_data, level, BSGS_RATIO, "none")
+
+        ctxt = encrypt_values(scheme, values, level=level)
+        ctxt_out_id = scheme.backend.EvaluateLinearTransform(
+            lt_id, ctxt.ids[0])
+        ctxt_out_id = scheme.backend.Rescale(ctxt_out_id)
+
+        ptxt_out_id = scheme.backend.Decrypt(ctxt_out_id)
+        result = scheme.backend.Decode(ptxt_out_id)
+
+        expected = [c * v for v in values]
+        assert_fhe_close(result, expected, atol=5e-1,
+                         msg="BSGS scale transform")
+        scheme.backend.DeleteLinearTransform(lt_id)
+
+    def test_cyclic_permutation_bsgs(self, scheme, slots, max_level):
+        """Cyclic shift via BSGS: single diagonal at index k."""
+        values = [float(i + 1) for i in range(slots)]
+        k = 3
+        level = max_level
+
+        diags_idxs = [k]
+        diags_data = [1.0] * slots
+
+        lt_id = scheme.backend.GenerateLinearTransform(
+            diags_idxs, diags_data, level, BSGS_RATIO, "none")
+
+        ctxt = encrypt_values(scheme, values, level=level)
+        ctxt_out_id = scheme.backend.EvaluateLinearTransform(
+            lt_id, ctxt.ids[0])
+        ctxt_out_id = scheme.backend.Rescale(ctxt_out_id)
+
+        ptxt_out_id = scheme.backend.Decrypt(ctxt_out_id)
+        result = scheme.backend.Decode(ptxt_out_id)
+
+        expected = [values[(i + k) % slots] for i in range(slots)]
+        assert_fhe_close(result, expected, atol=1e-1,
+                         msg=f"BSGS permute by {k}")
+        scheme.backend.DeleteLinearTransform(lt_id)
+
+    def test_multi_diagonal_bsgs(self, scheme, slots, max_level):
+        """Two diagonals via BSGS: identity + shift-by-1."""
+        values = [float(i + 1) for i in range(slots)]
+        level = max_level
+
+        diags_idxs = [0, 1]
+        diags_data = [1.0] * slots + [1.0] * slots
+
+        lt_id = scheme.backend.GenerateLinearTransform(
+            diags_idxs, diags_data, level, BSGS_RATIO, "none")
+
+        ctxt = encrypt_values(scheme, values, level=level)
+        ctxt_out_id = scheme.backend.EvaluateLinearTransform(
+            lt_id, ctxt.ids[0])
+        ctxt_out_id = scheme.backend.Rescale(ctxt_out_id)
+
+        ptxt_out_id = scheme.backend.Decrypt(ctxt_out_id)
+        result = scheme.backend.Decode(ptxt_out_id)
+
+        expected = [values[i] + values[(i + 1) % slots] for i in range(slots)]
+        assert_fhe_close(result, expected, atol=5e-1,
+                         msg="BSGS multi-diagonal")
+        scheme.backend.DeleteLinearTransform(lt_id)
+
+    def test_many_diagonals_bsgs(self, scheme, slots, max_level):
+        """Many diagonals to properly exercise the BSGS baby/giant split.
+
+        Uses 8 diagonals at varied offsets so that multiple giant steps
+        are needed (with bs=ceil(sqrt(8*2))=4, we get giant steps 0,1,2).
+        """
+        values = [float(i + 1) for i in range(slots)]
+        level = max_level
+
+        # 8 diagonals at indices 0,1,2,3,5,7,9,11 with distinct weights
+        diag_indices = [0, 1, 2, 3, 5, 7, 9, 11]
+        weights = [0.5, -0.3, 0.2, 0.1, -0.4, 0.6, -0.2, 0.3]
+
+        diags_data = []
+        for w in weights:
+            diags_data.extend([w] * slots)
+
+        lt_id = scheme.backend.GenerateLinearTransform(
+            diag_indices, diags_data, level, BSGS_RATIO, "none")
+
+        ctxt = encrypt_values(scheme, values, level=level)
+        ctxt_out_id = scheme.backend.EvaluateLinearTransform(
+            lt_id, ctxt.ids[0])
+        ctxt_out_id = scheme.backend.Rescale(ctxt_out_id)
+
+        ptxt_out_id = scheme.backend.Decrypt(ctxt_out_id)
+        result = scheme.backend.Decode(ptxt_out_id)
+
+        # expected[i] = sum_j weight_j * input[(i + diag_j) % slots]
+        expected = []
+        for i in range(slots):
+            val = sum(w * values[(i + d) % slots]
+                      for d, w in zip(diag_indices, weights))
+            expected.append(val)
+
+        assert_fhe_close(result, expected, atol=5e-1,
+                         msg="BSGS many-diagonals")
+        scheme.backend.DeleteLinearTransform(lt_id)
+
+    @pytest.mark.parametrize("num_diags", [50, 100, 144])
+    def test_stress_many_diagonals_bsgs(self, scheme, slots, max_level,
+                                         num_diags):
+        """Stress test with large numbers of diagonals (50, 100, 144).
+
+        144 diagonals matches the conv1 layer of ResNet that was causing
+        segfaults with rotate_batch. Uses random but reproducible weights.
+        """
+        import numpy as np
+        rng = np.random.default_rng(seed=42 + num_diags)
+
+        values = [float(i % 17) * 0.1 for i in range(slots)]
+        level = max_level
+
+        # Spread diagonals across the slot range
+        diag_indices = sorted(rng.choice(slots, size=num_diags,
+                                         replace=False).tolist())
+        weights = (rng.uniform(-0.5, 0.5, size=num_diags)).tolist()
+
+        diags_data = []
+        for w in weights:
+            diags_data.extend([w] * slots)
+
+        lt_id = scheme.backend.GenerateLinearTransform(
+            diag_indices, diags_data, level, BSGS_RATIO, "none")
+
+        ctxt = encrypt_values(scheme, values, level=level)
+        ctxt_out_id = scheme.backend.EvaluateLinearTransform(
+            lt_id, ctxt.ids[0])
+        ctxt_out_id = scheme.backend.Rescale(ctxt_out_id)
+
+        ptxt_out_id = scheme.backend.Decrypt(ctxt_out_id)
+        result = scheme.backend.Decode(ptxt_out_id)
+
+        # Compute expected cleartext result
+        expected = []
+        for i in range(slots):
+            val = sum(w * values[(i + d) % slots]
+                      for d, w in zip(diag_indices, weights))
+            expected.append(val)
+
+        assert_fhe_close(result, expected, atol=1.0,
+                         msg=f"BSGS stress {num_diags} diagonals")
+        scheme.backend.DeleteLinearTransform(lt_id)
+
+    def test_bsgs_vs_naive_consistency(self, scheme, slots, max_level):
+        """Verify BSGS and naive produce the same results."""
+        import numpy as np
+        rng = np.random.default_rng(seed=99)
+
+        values = [float(i % 13) * 0.2 for i in range(slots)]
+        level = max_level
+
+        num_diags = 30
+        diag_indices = sorted(rng.choice(slots, size=num_diags,
+                                         replace=False).tolist())
+        weights = (rng.uniform(-0.3, 0.3, size=num_diags)).tolist()
+
+        diags_data = []
+        for w in weights:
+            diags_data.extend([w] * slots)
+
+        # Evaluate with BSGS (bsgs_ratio=2)
+        lt_bsgs = scheme.backend.GenerateLinearTransform(
+            diag_indices, diags_data, level, BSGS_RATIO, "none")
+        ctxt1 = encrypt_values(scheme, values, level=level)
+        ct_bsgs = scheme.backend.EvaluateLinearTransform(
+            lt_bsgs, ctxt1.ids[0])
+        ct_bsgs = scheme.backend.Rescale(ct_bsgs)
+        pt_bsgs = scheme.backend.Decrypt(ct_bsgs)
+        result_bsgs = scheme.backend.Decode(pt_bsgs)
+
+        # Evaluate with naive (bsgs_ratio="none")
+        lt_naive = scheme.backend.GenerateLinearTransform(
+            diag_indices, diags_data, level, "none", "none")
+        ctxt2 = encrypt_values(scheme, values, level=level)
+        ct_naive = scheme.backend.EvaluateLinearTransform(
+            lt_naive, ctxt2.ids[0])
+        ct_naive = scheme.backend.Rescale(ct_naive)
+        pt_naive = scheme.backend.Decrypt(ct_naive)
+        result_naive = scheme.backend.Decode(pt_naive)
+
+        # Both should be close to each other
+        assert_fhe_close(result_bsgs, result_naive, atol=1.0,
+                         msg="BSGS vs naive consistency")
+
+        scheme.backend.DeleteLinearTransform(lt_bsgs)
+        scheme.backend.DeleteLinearTransform(lt_naive)


### PR DESCRIPTION
## Summary

Adds DeSiLo (`desilofhe`) as a new FHE backend for Orion, alongside the existing Lattigo backend.

- New backend at `orion/backend/desilo/bindings.py`, exposing the same ID-based interface as the Lattigo bindings so the Python wrapper layer and core run unchanged against either backend.
- Backend selection via the `backend` field in the config (`Scheme.setup_backend` dispatches `lattigo` vs `desilo`). CPU/GPU controlled by a new `device` field (`cpu` default, `gpu` for CUDA-enabled `desilofhe`).
- DeSiLo configs for LoLA, MLP, and ResNet (`configs/*_desilo.yml`) and corresponding example script updates.
- Oracle test suite under `tests/oracle/` that validates **both backends** against cleartext expected values across encode/decode, encrypt/decrypt, scalar/plaintext/ciphertext ops, rotation, rescale, polynomial evaluation, linear transforms (incl. BSGS), and bootstrap. Backend selectable via `--backend=lattigo|desilo`; bootstrap tests gated behind `-m slow`.
- README documents installation, example usage, and CPU/GPU device selection.

## Test plan
- [ ] `python3 -m pytest tests/oracle/ -v --backend=lattigo`
- [ ] `python3 -m pytest tests/oracle/ -v --backend=desilo`
- [ ] `python3 -m pytest tests/oracle/test_bootstrap.py -v -m slow --backend=desilo`
- [ ] Run examples on both backends with corresponding configs:
  - `python3 examples/run_lola.py configs/lola_desilo.yml`
  - `python3 examples/run_mlp.py configs/mlp_desilo.yml`
  - `python3 examples/run_resnet.py configs/resnet_desilo.yml`

## Notes
- This branch was developed off an earlier `baahl-nyu/orion:main` (before the HELRM additions). There may be merge conflicts in `README.md`, `examples/run_lola.py`, and `orion/nn/activation.py`. Happy to rebase if preferred.