### PR TITLE
Reduce memory pressure from plaintext generation

### DIFF
--- a/orion/backend/lattigo/lineartransform.go
+++ b/orion/backend/lattigo/lineartransform.go
@@ -3,6 +3,7 @@ package main
 import (
 	"C"
 	"math"
+	"runtime"
 	"unsafe"
 
 	"github.com/baahl-nyu/lattigo/v6/circuits/ckks/lintrans"
@@ -198,6 +199,8 @@ func RemovePlaintextDiagonals(transformID C.int) {
 	for diag := range linTransf.Vec {
 		linTransf.Vec[diag] = ringqp.Poly{}
 	}
+	// This is a good time to let Go GC know to reduce memory
+	runtime.GC()
 }
 
 //export RemoveRotationKeys

--- a/orion/backend/python/lt_evaluator.py
+++ b/orion/backend/python/lt_evaluator.py
@@ -108,7 +108,11 @@ class NewEvaluator:
             layer.create_dataset("output_min", data=output_min.item())
             layer.create_dataset("output_max", data=output_max.item())
 
-            diags_group = layer.require_group("diagonals", track_order=True)
+            if "diagonals" in layer:
+                diags_group = layer["diagonals"]
+            else:
+                diags_group = layer.create_group("diagonals",
+                                                 track_order=True)
             for (row, col), diags in diagonals.items():
                 block_idx = f"{row}_{col}"
                 block_diags_group = diags_group.create_group(block_idx, track_order=True)

--- a/orion/backend/python/lt_evaluator.py
+++ b/orion/backend/python/lt_evaluator.py
@@ -49,6 +49,7 @@ class NewEvaluator:
                 self.save_plaintext_diagonals(
                     layer_name, lintransf_id, row, col, diags_idxs
                 )
+                self.remove_plaintext_diagonals(lintransf_id)
 
         return lintransf_ids
     


### PR DESCRIPTION
During compilation, generated plaintexts accumulate in the memory with a significant footprint until Go GC steps in. This change adds a GC trigger to keep memory pressure managable.
