### PR TITLE
Add complex-lane CKKS encoding support

### DIFF
--- a/orion/backend/lattigo/bindings.py
+++ b/orion/backend/lattigo/bindings.py
@@ -348,6 +348,21 @@ class LattigoLibrary:
             restype=ArrayResultFloat,
         )
 
+        self.EncodeComplex = LattigoFunction(
+            self.lib.EncodeComplex,
+            argtypes=[
+                ctypes.POINTER(ctypes.c_float), ctypes.c_int,
+                ctypes.c_int,
+                ctypes.c_ulong,
+            ],
+            restype=ctypes.c_int
+        )
+        self.DecodeComplex = LattigoFunction(
+            self.lib.DecodeComplex,
+            argtypes=[ctypes.c_int],
+            restype=ArrayResultFloat,
+        )
+
     def setup_encryptor(self):
         self.NewEncryptor = LattigoFunction(
             self.lib.NewEncryptor,

--- a/orion/backend/lattigo/encoder.go
+++ b/orion/backend/lattigo/encoder.go
@@ -40,3 +40,52 @@ func Decode(
 	arrPtr, length := SliceToCArray(result, convertFloatToCFloat)
 	return arrPtr, length
 }
+
+// EncodeComplex encodes real/imaginary lane pairs into CKKS slots. The
+// input is an interleaved [re0, im0, re1, im1, ...] float array so that
+// both lanes of each complex slot can be filled (as opposed to Encode,
+// which only populates the real lane and leaves the imaginary lane zero).
+//
+//export EncodeComplex
+func EncodeComplex(
+	valuesPtr *C.float,
+	lenValues C.int,
+	level C.int,
+	scale C.ulong,
+) C.int {
+	raw := CArrayToSlice(valuesPtr, lenValues, convertCFloatToFloat)
+
+	values := make([]complex128, len(raw)/2)
+	for i := range values {
+		values[i] = complex(raw[2*i], raw[2*i+1])
+	}
+
+	plaintext := ckks.NewPlaintext(*scheme.Params, int(level))
+	plaintext.Scale = rlwe.NewScale(uint64(scale))
+
+	scheme.Encoder.Encode(values, plaintext)
+
+	idx := PushPlaintext(plaintext)
+	return C.int(idx)
+}
+
+// DecodeComplex returns the interleaved [re0, im0, re1, im1, ...] slot
+// values of a plaintext encoded with EncodeComplex.
+//
+//export DecodeComplex
+func DecodeComplex(
+	plaintextID C.int,
+) (*C.float, C.ulong) {
+	plaintext := RetrievePlaintext(int(plaintextID))
+	result := make([]complex128, scheme.Params.MaxSlots())
+	scheme.Encoder.Decode(plaintext, result)
+
+	interleaved := make([]float64, 2*len(result))
+	for i, v := range result {
+		interleaved[2*i] = real(v)
+		interleaved[2*i+1] = imag(v)
+	}
+
+	arrPtr, length := SliceToCArray(interleaved, convertFloatToCFloat)
+	return arrPtr, length
+}

--- a/orion/backend/python/encoder.py
+++ b/orion/backend/python/encoder.py
@@ -19,6 +19,8 @@ class NewEncoder:
                 f"Expected 'values' passed to encode() to be a either a list "
                 f"or a torch.Tensor, but got {type(values)}.")
 
+        is_complex = torch.is_complex(values)
+
         if not level:
             level = self.params.get_max_level()
         if not scale:
@@ -29,24 +31,37 @@ class NewEncoder:
 
         values = values.cpu()
         pad_length = (-num_elements) % num_slots
-        vector = torch.zeros(num_elements + pad_length)
+        dtype = torch.complex128 if is_complex else torch.float64
+        vector = torch.zeros(num_elements + pad_length, dtype=dtype)
         vector[:num_elements] = values.flatten()
         num_plaintexts = len(vector) // num_slots
 
         plaintext_ids = []
         for i in range(num_plaintexts):
-            to_encode = vector[i*num_slots:(i+1)*num_slots].tolist()
-            plaintext_id = self.backend.Encode(to_encode, level, scale)
+            chunk = vector[i*num_slots:(i+1)*num_slots]
+            if is_complex:
+                # Interleave as [re0, im0, re1, im1, ...] to fill both lanes.
+                interleaved = torch.view_as_real(chunk).flatten().tolist()
+                plaintext_id = self.backend.EncodeComplex(interleaved, level, scale)
+            else:
+                plaintext_id = self.backend.Encode(chunk.tolist(), level, scale)
             plaintext_ids.append(plaintext_id)
 
-        return PlainTensor(self.scheme, plaintext_ids, values.shape)
+        return PlainTensor(
+            self.scheme, plaintext_ids, values.shape, is_complex=is_complex)
 
     def decode(self, plaintensor: PlainTensor):
-        values = [] 
+        is_complex = getattr(plaintensor, "is_complex", False)
+        values = []
         for plaintext_id in plaintensor.ids:
-            values.extend(self.backend.Decode(plaintext_id))
+            if is_complex:
+                interleaved = torch.tensor(self.backend.DecodeComplex(plaintext_id))
+                values.extend(torch.view_as_complex(
+                    interleaved.view(-1, 2).contiguous()).tolist())
+            else:
+                values.extend(self.backend.Decode(plaintext_id))
 
-        values = torch.tensor(values)
+        values = torch.tensor(values, dtype=torch.complex128 if is_complex else torch.float64)
         if plaintensor.start is not None:
             values = values[plaintensor.start:plaintensor.stop:plaintensor.stride]
             return values

--- a/orion/backend/python/encryptor.py
+++ b/orion/backend/python/encryptor.py
@@ -20,7 +20,7 @@ class NewEncryptor:
             ciphertext_ids.append(ciphertext_id)
 
         return CipherTensor(
-            self.scheme, ciphertext_ids, plaintensor.shape, plaintensor.on_shape, plaintensor.start, plaintensor.stride, plaintensor.stop)
+            self.scheme, ciphertext_ids, plaintensor.shape, plaintensor.on_shape, plaintensor.start, plaintensor.stride, plaintensor.stop, plaintensor.is_complex)
     
     def decrypt(self, ciphertensor):
         plaintext_ids = []
@@ -29,5 +29,5 @@ class NewEncryptor:
             plaintext_ids.append(plaintext_id)
 
         return PlainTensor(
-           self.scheme,  plaintext_ids, ciphertensor.shape, ciphertensor.on_shape, ciphertensor.start, ciphertensor.stride, ciphertensor.stop
+           self.scheme,  plaintext_ids, ciphertensor.shape, ciphertensor.on_shape, ciphertensor.start, ciphertensor.stride, ciphertensor.stop, ciphertensor.is_complex
         )

--- a/orion/backend/python/tensors.py
+++ b/orion/backend/python/tensors.py
@@ -2,10 +2,11 @@ import sys
 import math
 
 class PlainTensor:
-    def __init__(self, scheme, ptxt_ids, shape, on_shape=None, start=None, stride=None, stop=None):
+    def __init__(self, scheme, ptxt_ids, shape, on_shape=None, start=None, stride=None, stop=None, is_complex=False):
         self.scheme = scheme
         self.backend = scheme.backend
         self.encoder = scheme.encoder
+        self.evaluator = scheme.evaluator
         
         self.ids = [ptxt_ids] if isinstance(ptxt_ids, int) else ptxt_ids
         self.shape = shape 
@@ -13,6 +14,7 @@ class PlainTensor:
         self.start = start
         self.stride = stride
         self.stop = stop
+        self.is_complex = is_complex
 
     #def __del__(self):
     #    if 'sys' in globals() and sys.modules and self.scheme:
@@ -35,13 +37,14 @@ class PlainTensor:
 
         mul_ids = []
         for i in range(len(self.ids)):
-            mul_id = self.evaluator.mul_ciphertext(
+            mul_id = self.evaluator.mul_plaintext(
                 other.ids[i], self.ids[i], in_place)
             mul_ids.append(mul_id)
 
         if in_place:
             return other
-        return CipherTensor(self.scheme, mul_ids, self.shape, self.on_shape, self.start, self.stride, self.stop) 
+        result_is_complex = self.is_complex or other.is_complex
+        return CipherTensor(self.scheme, mul_ids, self.shape, self.on_shape, self.start, self.stride, self.stop, result_is_complex) 
 
     def __mul__(self, other):
         return self.mul(other, in_place=False)     
@@ -82,7 +85,7 @@ class PlainTensor:
     
 
 class CipherTensor:
-    def __init__(self, scheme, ctxt_ids, shape, on_shape=None, start=None, stride=None, stop=None):
+    def __init__(self, scheme, ctxt_ids, shape, on_shape=None, start=None, stride=None, stop=None, is_complex=False):
         self.scheme = scheme
         self.backend = scheme.backend 
         self.encryptor = scheme.encryptor
@@ -95,6 +98,7 @@ class CipherTensor:
         self.start = start
         self.stride = stride
         self.stop = stop
+        self.is_complex = is_complex
 
     #def __del__(self):
     #    if 'sys' in globals() and sys.modules and self.scheme:
@@ -121,7 +125,7 @@ class CipherTensor:
             neg_id = self.evaluator.negate(ctxt)
             neg_ids.append(neg_id)
 
-        return CipherTensor(self.scheme, neg_ids, self.shape, self.on_shape, self.start, self.stride, self.stop)
+        return CipherTensor(self.scheme, neg_ids, self.shape, self.on_shape, self.start, self.stride, self.stop, self.is_complex)
     
     def add(self, other, in_place=False):
         self._check_valid(other)
@@ -145,7 +149,8 @@ class CipherTensor:
 
         if in_place:
             return self
-        return CipherTensor(self.scheme, add_ids, self.shape, self.on_shape, self.start, self.stride, self.stop)
+        result_is_complex = self.is_complex or getattr(other, "is_complex", False)
+        return CipherTensor(self.scheme, add_ids, self.shape, self.on_shape, self.start, self.stride, self.stop, result_is_complex)
     
     def __add__(self, other):
         return self.add(other, in_place=False)
@@ -175,7 +180,8 @@ class CipherTensor:
 
         if in_place:
             return self
-        return CipherTensor(self.scheme, sub_ids, self.shape, self.on_shape, self.start, self.stride, self.stop)
+        result_is_complex = self.is_complex or getattr(other, "is_complex", False)
+        return CipherTensor(self.scheme, sub_ids, self.shape, self.on_shape, self.start, self.stride, self.stop, result_is_complex)
     
     def __sub__(self, other):
         return self.sub(other, in_place=False)
@@ -205,7 +211,8 @@ class CipherTensor:
 
         if in_place:
             return self
-        return CipherTensor(self.scheme, mul_ids, self.shape, self.on_shape, self.start, self.stride, self.stop)
+        result_is_complex = self.is_complex or getattr(other, "is_complex", False)
+        return CipherTensor(self.scheme, mul_ids, self.shape, self.on_shape, self.start, self.stride, self.stop, result_is_complex)
     
     def __mul__(self, other):
         return self.mul(other, in_place=False)     
@@ -219,7 +226,7 @@ class CipherTensor:
             rot_id = self.evaluator.rotate(ctxt, amount, in_place)
             rot_ids.append(rot_id)
 
-        return CipherTensor(self.scheme, rot_ids, self.shape, self.on_shape, self.start, self.stride, self.stop)
+        return CipherTensor(self.scheme, rot_ids, self.shape, self.on_shape, self.start, self.stride, self.stop, self.is_complex)
     
     def _check_valid(self, other):
         return
@@ -263,7 +270,7 @@ class CipherTensor:
             btp_id = self.bootstrapper.bootstrap(ctxt, slots)
             btp_ids.append(btp_id)
 
-        return CipherTensor(self.scheme, btp_ids, self.shape, self.on_shape, self.start, self.stride, self.stop)
+        return CipherTensor(self.scheme, btp_ids, self.shape, self.on_shape, self.start, self.stride, self.stop, self.is_complex)
         
     def decrypt(self):
         return self.encryptor.decrypt(self)

--- a/tests/test_complex_encode.py
+++ b/tests/test_complex_encode.py
@@ -1,0 +1,144 @@
+import torch
+
+from orion.core.orion import scheme
+
+
+CONFIG = {
+    "ckks_params": {
+        "LogN": 13,
+        "LogQ": [45, 30, 30, 30],
+        "LogP": [50],
+        "LogScale": 30,
+        "H": 192,
+        "RingType": "Standard",
+    },
+    "orion": {
+        "margin": 2,
+        "embedding_method": "hybrid",
+        "backend": "lattigo",
+        "fuse_modules": True,
+        "debug": False,
+        "io_mode": "none",
+    },
+}
+
+
+def test_complex_encode_decode_round_trip():
+    """Encoding/decoding a complex tensor should preserve both lanes."""
+    scheme.init_scheme(CONFIG)
+
+    try:
+        values = torch.complex(
+            torch.arange(8, dtype=torch.float64),
+            torch.arange(8, dtype=torch.float64) * -1.0,
+        )
+
+        ptxt = scheme.encode(values)
+        assert ptxt.is_complex
+
+        decoded = scheme.decode(ptxt)
+        assert torch.is_complex(decoded)
+        torch.testing.assert_close(decoded, values, atol=1e-3, rtol=1e-3)
+    finally:
+        scheme.delete_scheme()
+
+
+def test_complex_encrypt_decrypt_round_trip():
+    """Encrypting/decrypting a complex plaintext should preserve both lanes."""
+    scheme.init_scheme(CONFIG)
+
+    try:
+        real = torch.tensor([1.5, -2.25, 3.0, 0.0], dtype=torch.float64)
+        imag = torch.tensor([0.5, 4.0, -1.0, 2.0], dtype=torch.float64)
+        values = torch.complex(real, imag)
+
+        ptxt = scheme.encode(values)
+        ctxt = scheme.encrypt(ptxt)
+        assert ctxt.is_complex
+
+        recovered_ptxt = scheme.decrypt(ctxt)
+        decoded = scheme.decode(recovered_ptxt)
+
+        torch.testing.assert_close(decoded, values, atol=1e-2, rtol=1e-2)
+    finally:
+        scheme.delete_scheme()
+
+
+def test_complex_ciphertext_times_real_plaintext():
+    """A complex-packed ciphertext times a real-only plaintext must scale
+    each lane independently (no cross terms), in both operand orders."""
+    scheme.init_scheme(CONFIG)
+
+    try:
+        real = torch.tensor([1.0, 2.0, 3.0, 4.0], dtype=torch.float64)
+        imag = torch.tensor([5.0, 6.0, 7.0, 8.0], dtype=torch.float64)
+        matrix = torch.complex(real, imag)
+        vector = torch.tensor([2.0, 0.5, -1.0, 3.0], dtype=torch.float64)
+
+        ct_matrix = scheme.encrypt(scheme.encode(matrix))
+        pt_vector = scheme.encode(vector)
+
+        expected = matrix * vector
+
+        # ciphertext * plaintext
+        ct_result = ct_matrix * pt_vector
+        assert ct_result.is_complex
+        decoded = scheme.decode(scheme.decrypt(ct_result))
+        torch.testing.assert_close(decoded, expected, atol=1e-2, rtol=1e-2)
+
+        # plaintext * ciphertext (commuted order)
+        ct_result_rev = pt_vector * ct_matrix
+        assert ct_result_rev.is_complex
+        decoded_rev = scheme.decode(scheme.decrypt(ct_result_rev))
+        torch.testing.assert_close(decoded_rev, expected, atol=1e-2, rtol=1e-2)
+    finally:
+        scheme.delete_scheme()
+
+
+def test_complex_ciphertext_times_real_ciphertext():
+    """A complex-packed ciphertext times a real-only ciphertext (both
+    encrypted) must scale each lane independently, in both operand orders."""
+    scheme.init_scheme(CONFIG)
+
+    try:
+        real = torch.tensor([1.0, 2.0, 3.0, 4.0], dtype=torch.float64)
+        imag = torch.tensor([5.0, 6.0, 7.0, 8.0], dtype=torch.float64)
+        matrix = torch.complex(real, imag)
+        vector = torch.tensor([2.0, 0.5, -1.0, 3.0], dtype=torch.float64)
+
+        ct_matrix = scheme.encrypt(scheme.encode(matrix))
+        ct_vector = scheme.encrypt(scheme.encode(vector))
+        assert not ct_vector.is_complex
+
+        expected = matrix * vector
+
+        # complex ciphertext * real ciphertext
+        ct_result = ct_matrix * ct_vector
+        assert ct_result.is_complex
+        decoded = scheme.decode(scheme.decrypt(ct_result))
+        torch.testing.assert_close(decoded, expected, atol=1e-2, rtol=1e-2)
+
+        # real ciphertext * complex ciphertext (commuted order)
+        ct_result_rev = ct_vector * ct_matrix
+        assert ct_result_rev.is_complex
+        decoded_rev = scheme.decode(scheme.decrypt(ct_result_rev))
+        torch.testing.assert_close(decoded_rev, expected, atol=1e-2, rtol=1e-2)
+    finally:
+        scheme.delete_scheme()
+
+
+def test_real_encode_is_unaffected():
+    """The existing real-only encode/decode path must stay unchanged."""
+    scheme.init_scheme(CONFIG)
+
+    try:
+        values = torch.tensor([1.0, 2.0, 3.0, 4.0], dtype=torch.float64)
+
+        ptxt = scheme.encode(values)
+        assert not ptxt.is_complex
+
+        decoded = scheme.decode(ptxt)
+        assert not torch.is_complex(decoded)
+        torch.testing.assert_close(decoded, values, atol=1e-3, rtol=1e-3)
+    finally:
+        scheme.delete_scheme()


### PR DESCRIPTION
Previously, Orion's Lattigo backend only ever encoded real-valued data: the Go wrapper's Encode/Decode functions marshaled a single real float64 array across the cgo boundary, so every plaintext's imaginary slot was implicitly zero even though the underlying lattigo library (and CKKS's "standard" ring type) natively supports packing two independent real values per slot as a complex number.

This change adds complex support through the full stack so both lanes of a CKKS slot can be filled and recovered:

- orion/backend/lattigo/encoder.go: add EncodeComplex/DecodeComplex C-exported functions. Values are encoded as an interleaved [re0, im0, re1, im1, ...] float array and packed into/out of a []complex128 slice, which lattigo's ckks.Encoder already accepts.

- orion/backend/lattigo/bindings.py: add ctypes signatures for the new EncodeComplex/DecodeComplex exports.

- orion/backend/python/encoder.py: encode()/decode() now detect torch.is_complex(values) and route through the complex backend calls (using torch.view_as_real/view_as_complex to interleave), while the existing real-only path is unchanged.

- orion/backend/python/tensors.py, encryptor.py: add an is_complex flag to PlainTensor/CipherTensor that is propagated through encode -> encrypt -> decrypt -> decode and through every op that returns a new tensor (add, sub, mul, roll, neg, bootstrap). The flag is now computed as the OR of both operands (previously only self's flag was considered), so mixed real/complex operations are tagged correctly regardless of operand order.

  While testing operand ordering, also fixed two pre-existing, unrelated bugs in PlainTensor.mul(): it never had access to scheme.evaluator (AttributeError on `plaintext * ciphertext`), and it called evaluator.mul_ciphertext (ciphertext-ciphertext) instead of evaluator.mul_plaintext (ciphertext-plaintext), silently feeding a plaintext id into the ciphertext-only relinearization path and producing incorrect results.

- tests/test_complex_encode.py: new tests covering complex encode/decode and encrypt/decrypt round trips, real-only encoding regression, and ciphertext x plaintext / ciphertext x ciphertext multiplication between a complex-packed operand and a real-only operand in both orders (validating that CKKS complex multiplication by a zero-imaginary operand scales each lane independently without cross-lane contamination).

Note: ciphertext-ciphertext multiplication between two operands that both carry nonzero imaginary data still mixes lanes per CKKS's complex multiplication rule and is out of scope for this change.